### PR TITLE
Fix responsive utilities

### DIFF
--- a/styles/layout/responsive-utilities/styles.less
+++ b/styles/layout/responsive-utilities/styles.less
@@ -102,7 +102,7 @@
 
     @media (min-width: @layout-screen-small-min-width) {
 
-      .hidden-mini-up {
+      .hidden-small-up {
 
         display: none !important;
 
@@ -112,7 +112,7 @@
 
     @media (max-width: @layout-screen-small-max-width) {
 
-      .hidden-mini-down {
+      .hidden-small-down {
 
         display: none !important;
 
@@ -132,7 +132,7 @@
 
     @media (min-width: @layout-screen-medium-min-width) {
 
-      .hidden-small-up {
+      .hidden-medium-up {
 
         display: none !important;
 
@@ -142,7 +142,7 @@
 
     @media (max-width: @layout-screen-medium-max-width) {
 
-      .hidden-small-down {
+      .hidden-medium-down {
 
         display: none !important;
 
@@ -162,7 +162,7 @@
 
     @media (min-width: @layout-screen-large-min-width) {
 
-      .hidden-medium-up {
+      .hidden-large-up {
 
         display: none !important;
 
@@ -172,7 +172,7 @@
 
     @media (max-width: @layout-screen-large-max-width) {
 
-      .hidden-medium-down {
+      .hidden-large-down {
 
         display: none !important;
 
@@ -192,7 +192,7 @@
 
     @media (min-width: @layout-screen-jumbo-min-width) {
 
-      .hidden-large-up {
+      .hidden-jumbo-up {
 
         display: none !important;
 
@@ -202,7 +202,7 @@
 
     @media (max-width: @layout-screen-jumbo-max-width) {
 
-      .hidden-large-down {
+      .hidden-jumbo-down {
 
         display: none !important;
 

--- a/styles/layout/styles.less
+++ b/styles/layout/styles.less
@@ -134,29 +134,9 @@ body {
 
 }
 
-/* Hidden */
-
-.hidden-up {
-
-  display: none !important;
-
-}
-
 
 
 & when (@layout-screen-small-enabled) {
-
-  @media (max-width: @layout-screen-small-min-width - 1) {
-
-    /* Hidden */
-
-    .hidden-down {
-
-      display: none !important;
-
-    }
-
-  }
 
   @media (min-width: @layout-screen-small-min-width) {
 
@@ -203,26 +183,6 @@ body {
     .flush-right-screen-small {
 
       margin-right: 0px !important;
-
-    }
-
-    /* Hidden */
-
-    .hidden-mini-up {
-
-      display: none !important;
-
-    }
-
-  }
-
-  @media (max-width: @layout-screen-small-max-width) {
-
-    /* Hidden */
-
-    .hidden-mini-down {
-
-      display: none !important;
 
     }
 
@@ -282,26 +242,6 @@ body {
 
     }
 
-    /* Hidden */
-
-    .hidden-small-up {
-
-      display: none !important;
-
-    }
-
-  }
-
-  @media (max-width: @layout-screen-medium-max-width) {
-
-    /* Hidden */
-
-    .hidden-small-down {
-
-      display: none !important;
-
-    }
-
   }
 
 }
@@ -355,26 +295,6 @@ body {
     .flush-right-screen-large {
 
       margin-right: 0px !important;
-
-    }
-
-    /* Hidden */
-
-    .hidden-medium-up {
-
-      display: none !important;
-
-    }
-
-  }
-
-  @media (max-width: @layout-screen-large-max-width) {
-
-    /* Hidden */
-
-    .hidden-medium-down {
-
-      display: none !important;
 
     }
 
@@ -433,54 +353,6 @@ body {
       margin-right: 0px !important;
 
     }
-
-    /* Hidden */
-
-    .hidden-large-up {
-
-      display: none !important;
-
-    }
-
-  }
-
-  /* Hidden */
-
-  .hidden-large-down {
-
-    display: none !important;
-
-  }
-
-}
-
-
-
-/* Print Visibility */
-
-@media print {
-
-  .visible-print-block {
-
-    display: block !important;
-
-  }
-
-  .visible-print-inline {
-
-    display: inline !important;
-
-  }
-
-  .visible-print-inline-block {
-
-    display: inline-block !important;
-
-  }
-
-  .hidden-print {
-
-    display: none !important;
 
   }
 


### PR DESCRIPTION
This PR removes the duplicate `hidden-*` classes that were defined in `styles/layout/styles.less` and fixes the class names in `styles/layout/responsive-utilities/styles.less` (they were all adhering to the old viewport width names).
