### PR TITLE
Add hidden-* classes for breakpoint ranges

### DIFF
--- a/styles/layout/responsive-utilities/styles.less
+++ b/styles/layout/responsive-utilities/styles.less
@@ -100,6 +100,16 @@
 
     }
 
+    @media (min-width: @layout-screen-small-min-width) and (max-width: @layout-screen-small-max-width) {
+
+      .hidden-small {
+
+        display: none !important;
+
+      }
+
+    }
+
     @media (min-width: @layout-screen-small-min-width) {
 
       .hidden-small-up {
@@ -140,6 +150,16 @@
 
     }
 
+    @media (min-width: @layout-screen-medium-min-width) and (max-width: @layout-screen-medium-max-width) {
+
+      .hidden-medium {
+
+        display: none !important;
+
+      }
+
+    }
+
     @media (max-width: @layout-screen-medium-max-width) {
 
       .hidden-medium-down {
@@ -170,6 +190,16 @@
 
     }
 
+    @media (min-width: @layout-screen-large-min-width) and (max-width: @layout-screen-large-max-width) {
+
+      .hidden-large {
+
+        display: none !important;
+
+      }
+
+    }
+
     @media (max-width: @layout-screen-large-max-width) {
 
       .hidden-large-down {
@@ -193,6 +223,16 @@
     @media (min-width: @layout-screen-jumbo-min-width) {
 
       .hidden-jumbo-up {
+
+        display: none !important;
+
+      }
+
+    }
+
+    @media (min-width: @layout-screen-jumbo-min-width) and (max-width: @layout-screen-jumbo-max-width) {
+
+      .hidden-jumbo {
 
         display: none !important;
 


### PR DESCRIPTION
It occurred to me that we might want to leverage these classes also. These will hide elements exclusively within the range of the breakpoints, where as the `*-up` and `*-down` classes allow for upper and lower limits of an element's visibility.
