### PR TITLE
Panel docs improvements

### DIFF
--- a/docs/_includes/components/buttons/buttons-flush.html
+++ b/docs/_includes/components/buttons/buttons-flush.html
@@ -1,0 +1,65 @@
+<!-- =================================================
+BEGIN: Narrow Buttons
+================================================== -->
+
+<section id="buttons-flush">
+
+  <h2>
+
+    Flush Buttons
+
+  </h2>
+
+  <p>
+
+    Use the class <code>.button-flush</code> to remove the horizontal padding within a button. This is useful when you want to assume button like behavior, particulary for <code>.button-link</code> styling, but do not want the added space created by the padding.
+
+  </p>
+
+  <!-- =================================================
+  BEGIN: Example
+  ================================================== -->
+
+  <div class="panel flush-bottom">
+
+    <div class="panel-cell">
+
+      <div class="button-collection button-collection-align-middle flush-bottom">
+
+        <a href="#" class="button button-flush">
+
+          Flush Button
+
+        </a>
+
+        <a href="#" class="button button-primary button-flush">
+
+          Flush Button
+
+        </a>
+
+      </div>
+
+    </div>
+
+    <div class="panel-cell panel-cell-light panel-cell-code-block">
+
+<pre class="prettyprint transparent flush lang-html">
+&lt;a href="#" class="button button-flush"&gt;
+  Flush Button
+&lt;/a&gt;
+</pre>
+
+    </div>
+
+  </div>
+
+  <!-- =================================================
+  END: Example
+  ================================================== -->
+
+</section>
+
+<!-- =================================================
+END: Narrow Buttons
+================================================== -->

--- a/docs/_includes/components/forms/forms-controls-inverse-styling.html
+++ b/docs/_includes/components/forms/forms-controls-inverse-styling.html
@@ -132,37 +132,11 @@ BEGIN: Form Control Sizes
 
             <div class="form-group">
 
-              <label class="form-control-toggle inverse form-control-toggle-custom">
+              <label class="inverse">
 
-                <input type="checkbox" checked/>
-
-                <span class="form-control-toggle-indicator"></span>
-
-                First Option
+                I am a&hellip;
 
               </label>
-
-              <label class="form-control-toggle inverse form-control-toggle-custom">
-
-                <input type="checkbox" />
-
-                <span class="form-control-toggle-indicator"></span>
-
-                Second Option
-
-              </label>
-
-            </div>
-
-          </div>
-
-        </div>
-
-        <div class="row">
-
-          <div class="column-small-12">
-
-            <div class="form-group">
 
               <label class="form-control-toggle inverse form-control-toggle-custom">
 
@@ -170,7 +144,7 @@ BEGIN: Form Control Sizes
 
                 <span class="form-control-toggle-indicator"></span>
 
-                First Option
+                Man
 
               </label>
 
@@ -180,7 +154,7 @@ BEGIN: Form Control Sizes
 
                 <span class="form-control-toggle-indicator"></span>
 
-                Second Option
+                Woman
 
               </label>
 
@@ -190,7 +164,7 @@ BEGIN: Form Control Sizes
 
                 <span class="form-control-toggle-indicator"></span>
 
-                Third Option
+                Unicorn
 
               </label>
 

--- a/docs/_includes/components/panels/panels-cells.html
+++ b/docs/_includes/components/panels/panels-cells.html
@@ -288,7 +288,7 @@ BEGIN: Panel Structure
 
         <div class="row">
 
-          <div class="column-12 column-small-6 column-medium-6 column-large-5 column-large-offset-1 column-jumbo-4 column-jumbo-offset-2">
+          <div class="column-12 column-small-6 column-medium-6 column-large-6 column-jumbo-5 column-jumbo-offset-1">
 
             <div class="panel">
 
@@ -322,7 +322,7 @@ BEGIN: Panel Structure
 
           </div>
 
-          <div class="column-12 column-small-6 column-medium-6 column-large-5 column-jumbo-4">
+          <div class="column-12 column-small-6 column-medium-6 column-large-6 column-jumbo-5">
 
             <div class="panel">
 
@@ -547,7 +547,7 @@ BEGIN: Panel Structure
 
         <div class="row">
 
-          <div class="column-12 column-small-6 column-medium-6 column-large-5 column-large-offset-1 column-jumbo-4 column-jumbo-offset-2">
+          <div class="column-12 column-small-6 column-medium-6 column-large-6 column-jumbo-5 column-jumbo-offset-1">
 
             <div class="panel">
 
@@ -571,7 +571,7 @@ BEGIN: Panel Structure
 
           </div>
 
-          <div class="column-12 column-small-6 column-medium-6 column-large-5 column-jumbo-4">
+          <div class="column-12 column-small-6 column-medium-6 column-large-6 column-jumbo-5">
 
             <div class="panel">
 

--- a/docs/_includes/components/panels/panels-styling.html
+++ b/docs/_includes/components/panels/panels-styling.html
@@ -40,7 +40,7 @@ BEGIN: Panel Styling
 
     <div class="panel panel-inverse flush-bottom">
 
-      <div class="panel-cell panel-cell-inverse">
+      <div class="panel-cell panel-cell-dark panel-cell-inverse">
 
         <div class="row">
 

--- a/docs/_includes/components/panels/panels-styling.html
+++ b/docs/_includes/components/panels/panels-styling.html
@@ -44,7 +44,7 @@ BEGIN: Panel Styling
 
         <div class="row">
 
-          <div class="column-12 column-small-8 column-small-offset-2 column-medium-8 column-medium-offset-2 column-large-6 column-large-offset-3 column-jumbo-4 column-jumbo-offset-4">
+          <div class="column-12 column-small-8 column-small-offset-2 column-medium-8 column-medium-offset-2 column-large-8 column-large-offset-2 column-jumbo-6 column-jumbo-offset-3">
 
             <div class="panel panel-inverse">
 
@@ -198,7 +198,7 @@ BEGIN: Panel Styling
 
         <div class="row">
 
-          <div class="column-12 column-small-8 column-small-offset-2 column-medium-8 column-medium-offset-2 column-large-6 column-large-offset-3 column-jumbo-4 column-jumbo-offset-4">
+          <div class="column-12 column-small-8 column-small-offset-2 column-medium-8 column-medium-offset-2 column-large-8 column-large-offset-2 column-jumbo-6 column-jumbo-offset-3">
 
             <div class="panel">
 

--- a/docs/components/buttons/index.html
+++ b/docs/components/buttons/index.html
@@ -29,6 +29,8 @@ page-navigation:
   link: "#buttons-wide"
 - label: "Narrow Button"
   link: "#buttons-narrow"
+- label: "Flush Button"
+  link: "#buttons-flush"
 - label: "Block Button"
   link: "#buttons-block"
   navigation:
@@ -108,6 +110,7 @@ BEGIN: Buttons
       {% include components/buttons/buttons-inverse-styling.html %}
       {% include components/buttons/buttons-wide.html %}
       {% include components/buttons/buttons-narrow.html %}
+      {% include components/buttons/buttons-flush.html %}
       {% include components/buttons/buttons-block.html %}
       {% include components/buttons/buttons-dropdowns.html %}
       {% include components/buttons/buttons-controls.html %}

--- a/docs/components/forms/index.html
+++ b/docs/components/forms/index.html
@@ -166,27 +166,33 @@ BEGIN: Forms
 
                 </label>
 
-                <label class="form-control-toggle">
+                <label class="form-control-toggle form-control-toggle-custom">
 
                   <input type="radio" name="radio-group-a" checked="checked">
+
+                  <span class="form-control-toggle-indicator"></span>
 
                   Man
 
                 </label>
 
-                <label class="form-control-toggle">
+                <label class="form-control-toggle form-control-toggle-custom">
 
                   <input type="radio" name="radio-group-a">
+
+                  <span class="form-control-toggle-indicator"></span>
 
                   Woman
 
                 </label>
 
-                <label class="form-control-toggle">
+                <label class="form-control-toggle form-control-toggle-custom">
 
                   <input type="radio" name="radio-group-a">
 
-                  Prefer not to say
+                  <span class="form-control-toggle-indicator"></span>
+
+                  Unicorn
 
                 </label>
 

--- a/docs/components/panels/index.html
+++ b/docs/components/panels/index.html
@@ -55,7 +55,7 @@ BEGIN: Panels
 
           <div class="row">
 
-            <div class="column-12 column-small-8 column-small-offset-2 column-medium-8 column-medium-offset-2 column-large-6 column-large-offset-3 column-jumbo-4 column-jumbo-offset-4">
+            <div class="column-12 column-small-8 column-small-offset-2 column-medium-8 column-medium-offset-2 column-large-8 column-large-offset-2 column-jumbo-6 column-jumbo-offset-3">
 
               <div class="panel panel-inline">
 

--- a/styles/components/button/shapes/button-jumbo/variables.less
+++ b/styles/components/button/shapes/button-jumbo/variables.less
@@ -19,7 +19,7 @@
 
 // Font Size
 
-@button-jumbo-font-size:                                                        1.3rem;
+@button-jumbo-font-size:                                                        1.2rem;
 @button-jumbo-font-size-screen-small:                                           null;
 @button-jumbo-font-size-screen-medium:                                          null;
 @button-jumbo-font-size-screen-large:                                           null;
@@ -27,7 +27,7 @@
 
 // Line Height
 
-@button-jumbo-line-height:                                                      1.3rem;
+@button-jumbo-line-height:                                                      1.2rem;
 @button-jumbo-line-height-screen-small:                                         null;
 @button-jumbo-line-height-screen-medium:                                        null;
 @button-jumbo-line-height-screen-large:                                         null;
@@ -41,10 +41,10 @@
 
 // Height
 
-@button-jumbo-height:                                                           56px;
+@button-jumbo-height:                                                           50px;
 @button-jumbo-height-screen-small:                                              null;
-@button-jumbo-height-screen-medium:                                             1.1 * @button-jumbo-height;
-@button-jumbo-height-screen-large:                                              1.2 * @button-jumbo-height;
+@button-jumbo-height-screen-medium:                                             null;
+@button-jumbo-height-screen-large:                                              54px;
 @button-jumbo-height-screen-jumbo:                                              null;
 
 // Border Radius
@@ -59,16 +59,16 @@
 
 @button-jumbo-dropdown-caret-width:                                             9px * (@button-jumbo-height / @button-height);
 @button-jumbo-dropdown-caret-width-screen-small:                                null;
-@button-jumbo-dropdown-caret-width-screen-medium:                               1.1 * @button-jumbo-dropdown-caret-width;
-@button-jumbo-dropdown-caret-width-screen-large:                                1.2 * @button-jumbo-dropdown-caret-width;
+@button-jumbo-dropdown-caret-width-screen-medium:                               null;
+@button-jumbo-dropdown-caret-width-screen-large:                                1.1 * @button-jumbo-dropdown-caret-width;
 @button-jumbo-dropdown-caret-width-screen-jumbo:                                null;
 
 // Dropdown Caret Height
 
 @button-jumbo-dropdown-caret-height:                                            5px * (@button-jumbo-height / @button-height);
 @button-jumbo-dropdown-caret-height-screen-small:                               null;
-@button-jumbo-dropdown-caret-height-screen-medium:                              1.1 * @button-jumbo-dropdown-caret-height;
-@button-jumbo-dropdown-caret-height-screen-large:                               1.2 * @button-jumbo-dropdown-caret-height;
+@button-jumbo-dropdown-caret-height-screen-medium:                              null;
+@button-jumbo-dropdown-caret-height-screen-large:                               1.1 * @button-jumbo-dropdown-caret-height;
 @button-jumbo-dropdown-caret-height-screen-jumbo:                               null;
 
 // Margin Top
@@ -83,16 +83,16 @@
 
 @button-jumbo-dropdown-caret-margin-left:                                       2.0rem * 0.25;
 @button-jumbo-dropdown-caret-margin-left-screen-small:                          null;
-@button-jumbo-dropdown-caret-margin-left-screen-medium:                         1.1 * @button-jumbo-dropdown-caret-margin-left;
-@button-jumbo-dropdown-caret-margin-left-screen-large:                          1.2 * @button-jumbo-dropdown-caret-margin-left;
+@button-jumbo-dropdown-caret-margin-left-screen-medium:                         null;
+@button-jumbo-dropdown-caret-margin-left-screen-large:                          null;
 @button-jumbo-dropdown-caret-margin-left-screen-jumbo:                          null;
 
 // button-jumbo Content Padding Horizontal
 
 @button-jumbo-content-padding-horizontal:                                       2.0rem * 0.25;
 @button-jumbo-content-padding-horizontal-screen-small:                          null;
-@button-jumbo-content-padding-horizontal-screen-medium:                         1.1 * @button-jumbo-content-padding-horizontal;
-@button-jumbo-content-padding-horizontal-screen-large:                          1.2 * @button-jumbo-content-padding-horizontal;
+@button-jumbo-content-padding-horizontal-screen-medium:                         null;
+@button-jumbo-content-padding-horizontal-screen-large:                          null;
 @button-jumbo-content-padding-horizontal-screen-jumbo:                          null;
 
 /* Margin */
@@ -151,16 +151,16 @@
 
 @button-jumbo-padding-left:                                                     2.0rem;
 @button-jumbo-padding-left-screen-small:                                        null;
-@button-jumbo-padding-left-screen-medium:                                       1.1 * @button-jumbo-padding-left;
-@button-jumbo-padding-left-screen-large:                                        1.2 * @button-jumbo-padding-left;
+@button-jumbo-padding-left-screen-medium:                                       null;
+@button-jumbo-padding-left-screen-large:                                        null;
 @button-jumbo-padding-left-screen-jumbo:                                        null;
 
 // Padding Right
 
 @button-jumbo-padding-right:                                                    2.0rem;
 @button-jumbo-padding-right-screen-small:                                       null;
-@button-jumbo-padding-right-screen-medium:                                      1.1 * @button-jumbo-padding-right;
-@button-jumbo-padding-right-screen-large:                                       1.2 * @button-jumbo-padding-right;
+@button-jumbo-padding-right-screen-medium:                                      null;
+@button-jumbo-padding-right-screen-large:                                       null;
 @button-jumbo-padding-right-screen-jumbo:                                       null;
 
 /* Layout Variants */

--- a/styles/components/button/shapes/button-large/variables.less
+++ b/styles/components/button/shapes/button-large/variables.less
@@ -27,7 +27,7 @@
 
 // Line Height
 
-@button-large-line-height:                                                      @button-large-font-size * 1.1;
+@button-large-line-height:                                                      1.1rem;
 @button-large-line-height-screen-small:                                         null;
 @button-large-line-height-screen-medium:                                        null;
 @button-large-line-height-screen-large:                                         null;
@@ -41,15 +41,15 @@
 
 // Height
 
-@button-large-height:                                                           46px;
+@button-large-height:                                                           44px;
 @button-large-height-screen-small:                                              null;
-@button-large-height-screen-medium:                                             1.1 * @button-large-height;
-@button-large-height-screen-large:                                              1.2 * @button-large-height;
+@button-large-height-screen-medium:                                             null;
+@button-large-height-screen-large:                                              46px;
 @button-large-height-screen-jumbo:                                              null;
 
 // Border Radius
 
-@button-large-border-radius:                                                    6px;
+@button-large-border-radius:                                                    5px;
 @button-large-border-radius-screen-small:                                       null;
 @button-large-border-radius-screen-medium:                                      null;
 @button-large-border-radius-screen-large:                                       null;
@@ -59,16 +59,16 @@
 
 @button-large-dropdown-caret-width:                                             9px * (@button-large-height / @button-height);
 @button-large-dropdown-caret-width-screen-small:                                null;
-@button-large-dropdown-caret-width-screen-medium:                               1.1 * @button-large-dropdown-caret-width;
-@button-large-dropdown-caret-width-screen-large:                                1.2 * @button-large-dropdown-caret-width;
+@button-large-dropdown-caret-width-screen-medium:                               null;
+@button-large-dropdown-caret-width-screen-large:                                1.1 * @button-large-dropdown-caret-width;
 @button-large-dropdown-caret-width-screen-jumbo:                                null;
 
 // Dropdown Caret Height
 
 @button-large-dropdown-caret-height:                                            5px * (@button-large-height / @button-height);
 @button-large-dropdown-caret-height-screen-small:                               null;
-@button-large-dropdown-caret-height-screen-medium:                              1.1 * @button-large-dropdown-caret-height;
-@button-large-dropdown-caret-height-screen-large:                               1.2 * @button-large-dropdown-caret-height;
+@button-large-dropdown-caret-height-screen-medium:                              null;
+@button-large-dropdown-caret-height-screen-large:                               1.1 * @button-large-dropdown-caret-height;
 @button-large-dropdown-caret-height-screen-jumbo:                               null;
 
 // Margin Top
@@ -81,18 +81,18 @@
 
 // Margin Top
 
-@button-large-dropdown-caret-margin-left:                                       2.0rem * 0.25;
+@button-large-dropdown-caret-margin-left:                                       1.5rem * 0.25;
 @button-large-dropdown-caret-margin-left-screen-small:                          null;
-@button-large-dropdown-caret-margin-left-screen-medium:                         1.1 * @button-large-dropdown-caret-margin-left;
-@button-large-dropdown-caret-margin-left-screen-large:                          1.2 * @button-large-dropdown-caret-margin-left;
+@button-large-dropdown-caret-margin-left-screen-medium:                         null;
+@button-large-dropdown-caret-margin-left-screen-large:                          null;
 @button-large-dropdown-caret-margin-left-screen-jumbo:                          null;
 
 // button-large Content Padding Horizontal
 
-@button-large-content-padding-horizontal:                                       2.0rem * 0.25;
+@button-large-content-padding-horizontal:                                       1.5rem * 0.25;
 @button-large-content-padding-horizontal-screen-small:                          null;
-@button-large-content-padding-horizontal-screen-medium:                         1.1 * @button-large-content-padding-horizontal;
-@button-large-content-padding-horizontal-screen-large:                          1.2 * @button-large-content-padding-horizontal;
+@button-large-content-padding-horizontal-screen-medium:                         null;
+@button-large-content-padding-horizontal-screen-large:                          null;
 @button-large-content-padding-horizontal-screen-jumbo:                          null;
 
 /* Margin */
@@ -149,18 +149,18 @@
 
 // Padding Left
 
-@button-large-padding-left:                                                     2.0rem;
+@button-large-padding-left:                                                     1.5rem;
 @button-large-padding-left-screen-small:                                        null;
-@button-large-padding-left-screen-medium:                                       1.1 * @button-large-padding-left;
-@button-large-padding-left-screen-large:                                        1.2 * @button-large-padding-left;
+@button-large-padding-left-screen-medium:                                       null;
+@button-large-padding-left-screen-large:                                        null;
 @button-large-padding-left-screen-jumbo:                                        null;
 
 // Padding Right
 
-@button-large-padding-right:                                                    2.0rem;
+@button-large-padding-right:                                                    1.5rem;
 @button-large-padding-right-screen-small:                                       null;
-@button-large-padding-right-screen-medium:                                      1.1 * @button-large-padding-right;
-@button-large-padding-right-screen-large:                                       1.2 * @button-large-padding-right;
+@button-large-padding-right-screen-medium:                                      null;
+@button-large-padding-right-screen-large:                                       null;
 @button-large-padding-right-screen-jumbo:                                       null;
 
 /* Layout Variants */

--- a/styles/components/button/shapes/button-mini/variables.less
+++ b/styles/components/button/shapes/button-mini/variables.less
@@ -19,7 +19,7 @@
 
 // Font Size
 
-@button-mini-font-size:                                                         0.75rem;
+@button-mini-font-size:                                                         0.8rem;
 @button-mini-font-size-screen-small:                                            null;
 @button-mini-font-size-screen-medium:                                           null;
 @button-mini-font-size-screen-large:                                            null;
@@ -27,7 +27,7 @@
 
 // Line Height
 
-@button-mini-line-height:                                                       0.75rem;
+@button-mini-line-height:                                                       0.8rem;
 @button-mini-line-height-screen-small:                                          null;
 @button-mini-line-height-screen-medium:                                         null;
 @button-mini-line-height-screen-large:                                          null;
@@ -41,10 +41,10 @@
 
 // Height
 
-@button-mini-height:                                                            24px;
+@button-mini-height:                                                            22px;
 @button-mini-height-screen-small:                                               null;
-@button-mini-height-screen-medium:                                              1.1 * @button-mini-height;
-@button-mini-height-screen-large:                                               1.2 * @button-mini-height;
+@button-mini-height-screen-medium:                                              null;
+@button-mini-height-screen-large:                                               24px;
 @button-mini-height-screen-jumbo:                                               null;
 
 // Border Radius
@@ -59,16 +59,16 @@
 
 @button-mini-dropdown-caret-width:                                              9px * (@button-mini-height / @button-height);
 @button-mini-dropdown-caret-width-screen-small:                                 null;
-@button-mini-dropdown-caret-width-screen-medium:                                1.1 * @button-mini-dropdown-caret-width;
-@button-mini-dropdown-caret-width-screen-large:                                 1.2 * @button-mini-dropdown-caret-width;
+@button-mini-dropdown-caret-width-screen-medium:                                null;
+@button-mini-dropdown-caret-width-screen-large:                                 1.1 * @button-mini-dropdown-caret-width;
 @button-mini-dropdown-caret-width-screen-jumbo:                                 null;
 
 // Dropdown Caret Height
 
 @button-mini-dropdown-caret-height:                                             5px * (@button-mini-height / @button-height);
 @button-mini-dropdown-caret-height-screen-small:                                null;
-@button-mini-dropdown-caret-height-screen-medium:                               1.1 * @button-mini-dropdown-caret-height;
-@button-mini-dropdown-caret-height-screen-large:                                1.2 * @button-mini-dropdown-caret-height;
+@button-mini-dropdown-caret-height-screen-medium:                               null;
+@button-mini-dropdown-caret-height-screen-large:                                1.1 * @button-mini-dropdown-caret-height;
 @button-mini-dropdown-caret-height-screen-jumbo:                                null;
 
 // Margin Top
@@ -83,16 +83,16 @@
 
 @button-mini-dropdown-caret-margin-left:                                        0.5rem * 0.25;
 @button-mini-dropdown-caret-margin-left-screen-small:                           null;
-@button-mini-dropdown-caret-margin-left-screen-medium:                          1.1 * @button-mini-dropdown-caret-margin-left;
-@button-mini-dropdown-caret-margin-left-screen-large:                           1.2 * @button-mini-dropdown-caret-margin-left;
+@button-mini-dropdown-caret-margin-left-screen-medium:                          null;
+@button-mini-dropdown-caret-margin-left-screen-large:                           null;
 @button-mini-dropdown-caret-margin-left-screen-jumbo:                           null;
 
 // button-mini Content Padding Horizontal
 
 @button-mini-content-padding-horizontal:                                        0.5rem * 0.25;
 @button-mini-content-padding-horizontal-screen-small:                           null;
-@button-mini-content-padding-horizontal-screen-medium:                          1.1 * @button-mini-content-padding-horizontal;
-@button-mini-content-padding-horizontal-screen-large:                           1.2 * @button-mini-content-padding-horizontal;
+@button-mini-content-padding-horizontal-screen-medium:                          null;
+@button-mini-content-padding-horizontal-screen-large:                           null;
 @button-mini-content-padding-horizontal-screen-jumbo:                           null;
 
 /* Margin */
@@ -151,16 +151,16 @@
 
 @button-mini-padding-left:                                                      0.5rem;
 @button-mini-padding-left-screen-small:                                         null;
-@button-mini-padding-left-screen-medium:                                        1.1 * @button-mini-padding-left;
-@button-mini-padding-left-screen-large:                                         1.2 * @button-mini-padding-left;
+@button-mini-padding-left-screen-medium:                                        null;
+@button-mini-padding-left-screen-large:                                         null;
 @button-mini-padding-left-screen-jumbo:                                         null;
 
 // Padding Right
 
 @button-mini-padding-right:                                                     0.5rem;
 @button-mini-padding-right-screen-small:                                        null;
-@button-mini-padding-right-screen-medium:                                       1.1 * @button-mini-padding-right;
-@button-mini-padding-right-screen-large:                                        1.2 * @button-mini-padding-right;
+@button-mini-padding-right-screen-medium:                                       null;
+@button-mini-padding-right-screen-large:                                        null;
 @button-mini-padding-right-screen-jumbo:                                        null;
 
 /* Layout Variants */

--- a/styles/components/button/shapes/button-small/variables.less
+++ b/styles/components/button/shapes/button-small/variables.less
@@ -41,15 +41,15 @@
 
 // Height
 
-@button-small-height:                                                           32px;
+@button-small-height:                                                           30px;
 @button-small-height-screen-small:                                              null;
-@button-small-height-screen-medium:                                             1.1 * @button-small-height;
-@button-small-height-screen-large:                                              1.2 * @button-small-height;
+@button-small-height-screen-medium:                                             null;
+@button-small-height-screen-large:                                              32px;
 @button-small-height-screen-jumbo:                                              null;
 
 // Border Radius
 
-@button-small-border-radius:                                                    4px;
+@button-small-border-radius:                                                    3px;
 @button-small-border-radius-screen-small:                                       null;
 @button-small-border-radius-screen-medium:                                      null;
 @button-small-border-radius-screen-large:                                       null;
@@ -59,16 +59,16 @@
 
 @button-small-dropdown-caret-width:                                             9px * (@button-small-height / @button-height);
 @button-small-dropdown-caret-width-screen-small:                                null;
-@button-small-dropdown-caret-width-screen-medium:                               1.1 * @button-small-dropdown-caret-width;
-@button-small-dropdown-caret-width-screen-large:                                1.2 * @button-small-dropdown-caret-width;
+@button-small-dropdown-caret-width-screen-medium:                               null;
+@button-small-dropdown-caret-width-screen-large:                                1.1 * @button-small-dropdown-caret-width;
 @button-small-dropdown-caret-width-screen-jumbo:                                null;
 
 // Dropdown Caret Height
 
 @button-small-dropdown-caret-height:                                            5px * (@button-small-height / @button-height);
 @button-small-dropdown-caret-height-screen-small:                               null;
-@button-small-dropdown-caret-height-screen-medium:                              1.1 * @button-small-dropdown-caret-height;
-@button-small-dropdown-caret-height-screen-large:                               1.2 * @button-small-dropdown-caret-height;
+@button-small-dropdown-caret-height-screen-medium:                              null;
+@button-small-dropdown-caret-height-screen-large:                               1.1 * @button-small-dropdown-caret-height;
 @button-small-dropdown-caret-height-screen-jumbo:                               null;
 
 // Margin Top
@@ -81,18 +81,18 @@
 
 // Margin Top
 
-@button-small-dropdown-caret-margin-left:                                       1.0rem * 0.25;
+@button-small-dropdown-caret-margin-left:                                       0.9rem * 0.25;
 @button-small-dropdown-caret-margin-left-screen-small:                          null;
-@button-small-dropdown-caret-margin-left-screen-medium:                         1.1 * @button-small-dropdown-caret-margin-left;
-@button-small-dropdown-caret-margin-left-screen-large:                          1.2 * @button-small-dropdown-caret-margin-left;
+@button-small-dropdown-caret-margin-left-screen-medium:                         null;
+@button-small-dropdown-caret-margin-left-screen-large:                          null;
 @button-small-dropdown-caret-margin-left-screen-jumbo:                          null;
 
 // button-small Content Padding Horizontal
 
-@button-small-content-padding-horizontal:                                       1.0rem * 0.25;
+@button-small-content-padding-horizontal:                                       0.9rem * 0.25;
 @button-small-content-padding-horizontal-screen-small:                          null;
-@button-small-content-padding-horizontal-screen-medium:                         1.1 * @button-small-content-padding-horizontal;
-@button-small-content-padding-horizontal-screen-large:                          1.2 * @button-small-content-padding-horizontal;
+@button-small-content-padding-horizontal-screen-medium:                         null;
+@button-small-content-padding-horizontal-screen-large:                          null;
 @button-small-content-padding-horizontal-screen-jumbo:                          null;
 
 /* Margin */
@@ -149,18 +149,18 @@
 
 // Padding Left
 
-@button-small-padding-left:                                                     1.0rem;
+@button-small-padding-left:                                                     0.9rem;
 @button-small-padding-left-screen-small:                                        null;
-@button-small-padding-left-screen-medium:                                       1.1 * @button-small-padding-left;
-@button-small-padding-left-screen-large:                                        1.2 * @button-small-padding-left;
+@button-small-padding-left-screen-medium:                                       null;
+@button-small-padding-left-screen-large:                                        null;
 @button-small-padding-left-screen-jumbo:                                        null;
 
 // Padding Right
 
-@button-small-padding-right:                                                    1.0rem;
+@button-small-padding-right:                                                    0.9rem;
 @button-small-padding-right-screen-small:                                       null;
-@button-small-padding-right-screen-medium:                                      1.1 * @button-small-padding-right;
-@button-small-padding-right-screen-large:                                       1.2 * @button-small-padding-right;
+@button-small-padding-right-screen-medium:                                      null;
+@button-small-padding-right-screen-large:                                       null;
 @button-small-padding-right-screen-jumbo:                                       null;
 
 /* Layout Variants */

--- a/styles/components/button/styles.less
+++ b/styles/components/button/styles.less
@@ -18,6 +18,12 @@
 
     /* Layout Variants */
 
+    &.button-flush {
+
+      .element-spacing(button, flush, null);
+
+    }
+
     &.button-narrow {
 
       .element-spacing(button, narrow, null);

--- a/styles/components/button/variables.less
+++ b/styles/components/button/variables.less
@@ -24,8 +24,8 @@
 @button-color:                                                                  color-lighten(@neutral, 0);
 @button-font-family:                                                            @font-family-sans-serif;
 @button-font-style:                                                             null;
-@button-font-weight:                                                            400;
-@button-text-transform:                                                         null;
+@button-font-weight:                                                            500;
+@button-text-transform:                                                         uppercase;
 @button-text-shadow:                                                            null;
 @button-text-decoration:                                                        none;
 @button-text-rendering:                                                         optimizelegibility;
@@ -339,7 +339,7 @@
 
 // Line Height
 
-@button-line-height:                                                            @button-font-size * 1.1;
+@button-line-height:                                                            1.0rem;
 @button-line-height-screen-small:                                               null;
 @button-line-height-screen-medium:                                              null;
 @button-line-height-screen-large:                                               null;
@@ -353,15 +353,15 @@
 
 // Height
 
-@button-height:                                                                 38px;
+@button-height:                                                                 36px;
 @button-height-screen-small:                                                    null;
-@button-height-screen-medium:                                                   1.1 * @button-height;
-@button-height-screen-large:                                                    1.2 * @button-height;
+@button-height-screen-medium:                                                   null;
+@button-height-screen-large:                                                    38px;
 @button-height-screen-jumbo:                                                    null;
 
 // Border Radius
 
-@button-border-radius:                                                          5px;
+@button-border-radius:                                                          4px;
 @button-border-radius-screen-small:                                             null;
 @button-border-radius-screen-medium:                                            null;
 @button-border-radius-screen-large:                                             null;
@@ -371,16 +371,16 @@
 
 @button-dropdown-caret-width:                                                   9px;
 @button-dropdown-caret-width-screen-small:                                      null;
-@button-dropdown-caret-width-screen-medium:                                     1.1 * @button-dropdown-caret-width;
-@button-dropdown-caret-width-screen-large:                                      1.2 * @button-dropdown-caret-width;
+@button-dropdown-caret-width-screen-medium:                                     null;
+@button-dropdown-caret-width-screen-large:                                      1.1 * @button-dropdown-caret-width;
 @button-dropdown-caret-width-screen-jumbo:                                      null;
 
 // Dropdown Caret Height
 
 @button-dropdown-caret-height:                                                  5px;
 @button-dropdown-caret-height-screen-small:                                     null;
-@button-dropdown-caret-height-screen-medium:                                    1.1 * @button-dropdown-caret-height;
-@button-dropdown-caret-height-screen-large:                                     1.2 * @button-dropdown-caret-height;
+@button-dropdown-caret-height-screen-medium:                                    null;
+@button-dropdown-caret-height-screen-large:                                     1.1 * @button-dropdown-caret-height;
 @button-dropdown-caret-height-screen-jumbo:                                     null;
 
 // Margin Top
@@ -393,18 +393,18 @@
 
 // Margin Top
 
-@button-dropdown-caret-margin-left:                                             1.5rem * 0.25;
+@button-dropdown-caret-margin-left:                                             1.25rem * 0.25;
 @button-dropdown-caret-margin-left-screen-small:                                null;
-@button-dropdown-caret-margin-left-screen-medium:                               1.1 * @button-dropdown-caret-margin-left;
-@button-dropdown-caret-margin-left-screen-large:                                1.2 * @button-dropdown-caret-margin-left;
+@button-dropdown-caret-margin-left-screen-medium:                               null;
+@button-dropdown-caret-margin-left-screen-large:                                null;
 @button-dropdown-caret-margin-left-screen-jumbo:                                null;
 
 // Button Content Padding Horizontal
 
-@button-content-padding-horizontal:                                             1.5rem * 0.25;
+@button-content-padding-horizontal:                                             1.25rem * 0.25;
 @button-content-padding-horizontal-screen-small:                                null;
-@button-content-padding-horizontal-screen-medium:                               1.1 * @button-content-padding-horizontal;
-@button-content-padding-horizontal-screen-large:                                1.2 * @button-content-padding-horizontal;
+@button-content-padding-horizontal-screen-medium:                               null;
+@button-content-padding-horizontal-screen-large:                                null;
 @button-content-padding-horizontal-screen-jumbo:                                null;
 
 /* Margin */
@@ -461,21 +461,33 @@
 
 // Padding Left
 
-@button-padding-left:                                                           1.5rem;
+@button-padding-left:                                                           1.25rem;
 @button-padding-left-screen-small:                                              null;
-@button-padding-left-screen-medium:                                             1.1 * @button-padding-left;
-@button-padding-left-screen-large:                                              1.2 * @button-padding-left;
+@button-padding-left-screen-medium:                                             null;
+@button-padding-left-screen-large:                                              null;
 @button-padding-left-screen-jumbo:                                              null;
 
 // Padding Right
 
-@button-padding-right:                                                          1.5rem;
+@button-padding-right:                                                          1.25rem;
 @button-padding-right-screen-small:                                             null;
-@button-padding-right-screen-medium:                                            1.1 * @button-padding-right;
-@button-padding-right-screen-large:                                             1.2 * @button-padding-right;
+@button-padding-right-screen-medium:                                            null;
+@button-padding-right-screen-large:                                             null;
 @button-padding-right-screen-jumbo:                                             null;
 
 /* Layout Variants */
+
+// Flush
+
+@button-narrow-margin-top-scale:                                                null;
+@button-narrow-margin-bottom-scale:                                             null;
+@button-narrow-margin-left-scale:                                               null;
+@button-narrow-margin-right-scale:                                              null;
+
+@button-narrow-padding-top-scale:                                               null;
+@button-narrow-padding-bottom-scale:                                            null;
+@button-narrow-padding-left-scale:                                              0.0;
+@button-narrow-padding-right-scale:                                             0.0;
 
 // Narrow
 

--- a/styles/components/button/variables.less
+++ b/styles/components/button/variables.less
@@ -479,15 +479,15 @@
 
 // Flush
 
-@button-narrow-margin-top-scale:                                                null;
-@button-narrow-margin-bottom-scale:                                             null;
-@button-narrow-margin-left-scale:                                               null;
-@button-narrow-margin-right-scale:                                              null;
+@button-flush-margin-top-scale:                                                 null;
+@button-flush-margin-bottom-scale:                                              null;
+@button-flush-margin-left-scale:                                                null;
+@button-flush-margin-right-scale:                                               null;
 
-@button-narrow-padding-top-scale:                                               null;
-@button-narrow-padding-bottom-scale:                                            null;
-@button-narrow-padding-left-scale:                                              0.0;
-@button-narrow-padding-right-scale:                                             0.0;
+@button-flush-padding-top-scale:                                                null;
+@button-flush-padding-bottom-scale:                                             null;
+@button-flush-padding-left-scale:                                               0.0;
+@button-flush-padding-right-scale:                                              0.0;
 
 // Narrow
 

--- a/styles/components/form/form-control/shapes/form-control-jumbo/styles.less
+++ b/styles/components/form/form-control/shapes/form-control-jumbo/styles.less
@@ -51,8 +51,8 @@
 
     &:after {
 
-      .property-variant(form-control-jumbo, margin-left, null);
-      .property-variant(form-control-jumbo, margin-top, null);
+      .property-variant(form-control-jumbo-caret, margin-left, null);
+      .property-variant(form-control-jumbo-caret, margin-top, null);
       .property-variant(form-control-jumbo, margin-right, padding-right, null, null);
 
       & when not (@form-control-jumbo-caret-width = null) {

--- a/styles/components/form/form-control/shapes/form-control-jumbo/variables.less
+++ b/styles/components/form/form-control/shapes/form-control-jumbo/variables.less
@@ -19,7 +19,7 @@
 
 // Font Size
 
-@form-control-jumbo-font-size:                                                  1.3rem;
+@form-control-jumbo-font-size:                                                  1.2rem;
 @form-control-jumbo-font-size-screen-small:                                     null;
 @form-control-jumbo-font-size-screen-medium:                                    null;
 @form-control-jumbo-font-size-screen-large:                                     null;
@@ -27,7 +27,7 @@
 
 // Line Height
 
-@form-control-jumbo-line-height:                                                1.3rem;
+@form-control-jumbo-line-height:                                                1.2rem;
 @form-control-jumbo-line-height-screen-small:                                   null;
 @form-control-jumbo-line-height-screen-medium:                                  null;
 @form-control-jumbo-line-height-screen-large:                                   null;
@@ -41,10 +41,10 @@
 
 // Height
 
-@form-control-jumbo-height:                                                     56px;
+@form-control-jumbo-height:                                                     50px;
 @form-control-jumbo-height-screen-small:                                        null;
-@form-control-jumbo-height-screen-medium:                                       1.1 * @form-control-jumbo-height;
-@form-control-jumbo-height-screen-large:                                        1.2 * @form-control-jumbo-height;
+@form-control-jumbo-height-screen-medium:                                       null;
+@form-control-jumbo-height-screen-large:                                        54px;
 @form-control-jumbo-height-screen-jumbo:                                        null;
 
 // Border Radius
@@ -59,16 +59,16 @@
 
 @form-control-jumbo-caret-width:                                                9px * (@form-control-jumbo-height / @form-control-height);
 @form-control-jumbo-caret-width-screen-small:                                   null;
-@form-control-jumbo-caret-width-screen-medium:                                  1.1 * @form-control-jumbo-caret-width;
-@form-control-jumbo-caret-width-screen-large:                                   1.2 * @form-control-jumbo-caret-width;
+@form-control-jumbo-caret-width-screen-medium:                                  null;
+@form-control-jumbo-caret-width-screen-large:                                   1.1 * @form-control-jumbo-caret-width;
 @form-control-jumbo-caret-width-screen-jumbo:                                   null;
 
 // Dropdown Caret Height
 
 @form-control-jumbo-caret-height:                                               5px * (@form-control-jumbo-height / @form-control-height);
 @form-control-jumbo-caret-height-screen-small:                                  null;
-@form-control-jumbo-caret-height-screen-medium:                                 1.1 * @form-control-jumbo-caret-height;
-@form-control-jumbo-caret-height-screen-large:                                  1.2 * @form-control-jumbo-caret-height;
+@form-control-jumbo-caret-height-screen-medium:                                 null;
+@form-control-jumbo-caret-height-screen-large:                                  1.1 * @form-control-jumbo-caret-height;
 @form-control-jumbo-caret-height-screen-jumbo:                                  null;
 
 // Dropdown Caret Margin Top
@@ -81,18 +81,18 @@
 
 // Dropdown Caret Margin Left
 
-@form-control-jumbo-caret-margin-left:                                          1.5rem * 0.25;
+@form-control-jumbo-caret-margin-left:                                          2.0rem * 0.25;
 @form-control-jumbo-caret-margin-left-screen-small:                             null;
-@form-control-jumbo-caret-margin-left-screen-medium:                            1.1 * @form-control-jumbo-caret-margin-left;
-@form-control-jumbo-caret-margin-left-screen-large:                             1.2 * @form-control-jumbo-caret-margin-left;
+@form-control-jumbo-caret-margin-left-screen-medium:                            null;
+@form-control-jumbo-caret-margin-left-screen-large:                             null;
 @form-control-jumbo-caret-margin-left-screen-jumbo:                             null;
 
 // Form Control Group Add On Padding Horizontal
 
-@form-control-jumbo-add-on-padding-horizontal:                                  1.5rem * 0.5;
+@form-control-jumbo-add-on-padding-horizontal:                                  2.0rem * 0.5;
 @form-control-jumbo-add-on-padding-horizontal-screen-small:                     null;
-@form-control-jumbo-add-on-padding-horizontal-screen-medium:                    1.1 * @form-control-jumbo-add-on-padding-horizontal;
-@form-control-jumbo-add-on-padding-horizontal-screen-large:                     1.2 * @form-control-jumbo-add-on-padding-horizontal;
+@form-control-jumbo-add-on-padding-horizontal-screen-medium:                    null;
+@form-control-jumbo-add-on-padding-horizontal-screen-large:                     null;
 @form-control-jumbo-add-on-padding-horizontal-screen-jumbo:                     null;
 
 /* Margin */
@@ -149,18 +149,18 @@
 
 // Padding Left
 
-@form-control-jumbo-padding-left:                                               1.5rem;
+@form-control-jumbo-padding-left:                                               2.0rem;
 @form-control-jumbo-padding-left-screen-small:                                  null;
-@form-control-jumbo-padding-left-screen-medium:                                 1.1 * @form-control-jumbo-padding-left;
-@form-control-jumbo-padding-left-screen-large:                                  1.2 * @form-control-jumbo-padding-left;
+@form-control-jumbo-padding-left-screen-medium:                                 null;
+@form-control-jumbo-padding-left-screen-large:                                  null;
 @form-control-jumbo-padding-left-screen-jumbo:                                  null;
 
 // Padding Right
 
-@form-control-jumbo-padding-right:                                              1.5rem;
+@form-control-jumbo-padding-right:                                              2.0rem;
 @form-control-jumbo-padding-right-screen-small:                                 null;
-@form-control-jumbo-padding-right-screen-medium:                                1.1 * @form-control-jumbo-padding-right;
-@form-control-jumbo-padding-right-screen-large:                                 1.2 * @form-control-jumbo-padding-right;
+@form-control-jumbo-padding-right-screen-medium:                                null;
+@form-control-jumbo-padding-right-screen-large:                                 null;
 @form-control-jumbo-padding-right-screen-jumbo:                                 null;
 
 /* Rounded form-control */

--- a/styles/components/form/form-control/shapes/form-control-large/styles.less
+++ b/styles/components/form/form-control/shapes/form-control-large/styles.less
@@ -51,8 +51,8 @@
 
     &:after {
 
-      .property-variant(form-control-large, margin-left, null);
-      .property-variant(form-control-large, margin-top, null);
+      .property-variant(form-control-large-caret, margin-left, null);
+      .property-variant(form-control-large-caret, margin-top, null);
       .property-variant(form-control-large, margin-right, padding-right, null, null);
 
       & when not (@form-control-large-caret-width = null) {

--- a/styles/components/form/form-control/shapes/form-control-large/variables.less
+++ b/styles/components/form/form-control/shapes/form-control-large/variables.less
@@ -41,15 +41,15 @@
 
 // Height
 
-@form-control-large-height:                                                     46px;
+@form-control-large-height:                                                     44px;
 @form-control-large-height-screen-small:                                        null;
-@form-control-large-height-screen-medium:                                       1.1 * @form-control-large-height;
-@form-control-large-height-screen-large:                                        1.2 * @form-control-large-height;
+@form-control-large-height-screen-medium:                                       null;
+@form-control-large-height-screen-large:                                        46px;
 @form-control-large-height-screen-jumbo:                                        null;
 
 // Border Radius
 
-@form-control-large-border-radius:                                              6px;
+@form-control-large-border-radius:                                              5px;
 @form-control-large-border-radius-screen-small:                                 null;
 @form-control-large-border-radius-screen-medium:                                null;
 @form-control-large-border-radius-screen-large:                                 null;
@@ -59,16 +59,16 @@
 
 @form-control-large-caret-width:                                                9px * (@form-control-large-height / @form-control-height);
 @form-control-large-caret-width-screen-small:                                   null;
-@form-control-large-caret-width-screen-medium:                                  1.1 * @form-control-large-caret-width;
-@form-control-large-caret-width-screen-large:                                   1.2 * @form-control-large-caret-width;
+@form-control-large-caret-width-screen-medium:                                  null;
+@form-control-large-caret-width-screen-large:                                   1.1 * @form-control-large-caret-width;
 @form-control-large-caret-width-screen-jumbo:                                   null;
 
 // Dropdown Caret Height
 
 @form-control-large-caret-height:                                               5px * (@form-control-large-height / @form-control-height);
 @form-control-large-caret-height-screen-small:                                  null;
-@form-control-large-caret-height-screen-medium:                                 1.1 * @form-control-large-caret-height;
-@form-control-large-caret-height-screen-large:                                  1.2 * @form-control-large-caret-height;
+@form-control-large-caret-height-screen-medium:                                 null;
+@form-control-large-caret-height-screen-large:                                  1.1 * @form-control-large-caret-height;
 @form-control-large-caret-height-screen-jumbo:                                  null;
 
 // Dropdown Caret Margin Top
@@ -81,18 +81,18 @@
 
 // Dropdown Caret Margin Left
 
-@form-control-large-caret-margin-left:                                          1.25rem * 0.25;
+@form-control-large-caret-margin-left:                                          1.5rem * 0.25;
 @form-control-large-caret-margin-left-screen-small:                             null;
-@form-control-large-caret-margin-left-screen-medium:                            1.1 * @form-control-large-caret-margin-left;
-@form-control-large-caret-margin-left-screen-large:                             1.2 * @form-control-large-caret-margin-left;
+@form-control-large-caret-margin-left-screen-medium:                            null;
+@form-control-large-caret-margin-left-screen-large:                             null;
 @form-control-large-caret-margin-left-screen-jumbo:                             null;
 
 // Form Control Group Add On Padding Horizontal
 
-@form-control-large-add-on-padding-horizontal:                                  1.25rem * 0.5;
+@form-control-large-add-on-padding-horizontal:                                  1.5rem * 0.5;
 @form-control-large-add-on-padding-horizontal-screen-small:                     null;
-@form-control-large-add-on-padding-horizontal-screen-medium:                    1.1 * @form-control-large-add-on-padding-horizontal;
-@form-control-large-add-on-padding-horizontal-screen-large:                     1.2 * @form-control-large-add-on-padding-horizontal;
+@form-control-large-add-on-padding-horizontal-screen-medium:                    null;
+@form-control-large-add-on-padding-horizontal-screen-large:                     null;
 @form-control-large-add-on-padding-horizontal-screen-jumbo:                     null;
 
 /* Margin */
@@ -149,18 +149,18 @@
 
 // Padding Left
 
-@form-control-large-padding-left:                                               1.25rem;
+@form-control-large-padding-left:                                               1.5rem;
 @form-control-large-padding-left-screen-small:                                  null;
-@form-control-large-padding-left-screen-medium:                                 1.1 * @form-control-large-padding-left;
-@form-control-large-padding-left-screen-large:                                  1.2 * @form-control-large-padding-left;
+@form-control-large-padding-left-screen-medium:                                 null;
+@form-control-large-padding-left-screen-large:                                  null;
 @form-control-large-padding-left-screen-jumbo:                                  null;
 
 // Padding Right
 
-@form-control-large-padding-right:                                              1.25rem;
+@form-control-large-padding-right:                                              1.5rem;
 @form-control-large-padding-right-screen-small:                                 null;
-@form-control-large-padding-right-screen-medium:                                1.1 * @form-control-large-padding-right;
-@form-control-large-padding-right-screen-large:                                 1.2 * @form-control-large-padding-right;
+@form-control-large-padding-right-screen-medium:                                null;
+@form-control-large-padding-right-screen-large:                                 null;
 @form-control-large-padding-right-screen-jumbo:                                 null;
 
 /* Rounded form-control */

--- a/styles/components/form/form-control/shapes/form-control-mini/styles.less
+++ b/styles/components/form/form-control/shapes/form-control-mini/styles.less
@@ -51,8 +51,8 @@
 
     &:after {
 
-      .property-variant(form-control-mini, margin-left, null);
-      .property-variant(form-control-mini, margin-top, null);
+      .property-variant(form-control-mini-caret, margin-left, null);
+      .property-variant(form-control-mini-caret, margin-top, null);
       .property-variant(form-control-mini, margin-right, padding-right, null, null);
 
       & when not (@form-control-mini-caret-width = null) {

--- a/styles/components/form/form-control/shapes/form-control-mini/variables.less
+++ b/styles/components/form/form-control/shapes/form-control-mini/variables.less
@@ -19,7 +19,7 @@
 
 // Font Size
 
-@form-control-mini-font-size:                                                   0.75rem;
+@form-control-mini-font-size:                                                   0.8rem;
 @form-control-mini-font-size-screen-small:                                      null;
 @form-control-mini-font-size-screen-medium:                                     null;
 @form-control-mini-font-size-screen-large:                                      null;
@@ -27,7 +27,7 @@
 
 // Line Height
 
-@form-control-mini-line-height:                                                 0.75rem;
+@form-control-mini-line-height:                                                 0.8rem;
 @form-control-mini-line-height-screen-small:                                    null;
 @form-control-mini-line-height-screen-medium:                                   null;
 @form-control-mini-line-height-screen-large:                                    null;
@@ -41,10 +41,10 @@
 
 // Height
 
-@form-control-mini-height:                                                      24px;
+@form-control-mini-height:                                                      22px;
 @form-control-mini-height-screen-small:                                         null;
-@form-control-mini-height-screen-medium:                                        1.1 * @form-control-mini-height;
-@form-control-mini-height-screen-large:                                         1.2 * @form-control-mini-height;
+@form-control-mini-height-screen-medium:                                        null;
+@form-control-mini-height-screen-large:                                         24px;
 @form-control-mini-height-screen-jumbo:                                         null;
 
 // Border Radius
@@ -59,16 +59,16 @@
 
 @form-control-mini-caret-width:                                                 9px * (@form-control-mini-height / @form-control-height);
 @form-control-mini-caret-width-screen-small:                                    null;
-@form-control-mini-caret-width-screen-medium:                                   1.1 * @form-control-mini-caret-width;
-@form-control-mini-caret-width-screen-large:                                    1.2 * @form-control-mini-caret-width;
+@form-control-mini-caret-width-screen-medium:                                   null;
+@form-control-mini-caret-width-screen-large:                                    1.1 * @form-control-mini-caret-width;
 @form-control-mini-caret-width-screen-jumbo:                                    null;
 
 // Dropdown Caret Height
 
 @form-control-mini-caret-height:                                                5px * (@form-control-mini-height / @form-control-height);
 @form-control-mini-caret-height-screen-small:                                   null;
-@form-control-mini-caret-height-screen-medium:                                  1.1 * @form-control-mini-caret-height;
-@form-control-mini-caret-height-screen-large:                                   1.2 * @form-control-mini-caret-height;
+@form-control-mini-caret-height-screen-medium:                                  null;
+@form-control-mini-caret-height-screen-large:                                   1.1 * @form-control-mini-caret-height;
 @form-control-mini-caret-height-screen-jumbo:                                   null;
 
 // Dropdown Caret Margin Top
@@ -83,16 +83,16 @@
 
 @form-control-mini-caret-margin-left:                                           0.5rem * 0.25;
 @form-control-mini-caret-margin-left-screen-small:                              null;
-@form-control-mini-caret-margin-left-screen-medium:                             1.1 * @form-control-mini-caret-margin-left;
-@form-control-mini-caret-margin-left-screen-large:                              1.2 * @form-control-mini-caret-margin-left;
+@form-control-mini-caret-margin-left-screen-medium:                             null;
+@form-control-mini-caret-margin-left-screen-large:                              null;
 @form-control-mini-caret-margin-left-screen-jumbo:                              null;
 
 // Form Control Group Add On Padding Horizontal
 
 @form-control-mini-add-on-padding-horizontal:                                   0.5rem * 0.5;
 @form-control-mini-add-on-padding-horizontal-screen-small:                      null;
-@form-control-mini-add-on-padding-horizontal-screen-medium:                     1.1 * @form-control-mini-add-on-padding-horizontal;
-@form-control-mini-add-on-padding-horizontal-screen-large:                      1.2 * @form-control-mini-add-on-padding-horizontal;
+@form-control-mini-add-on-padding-horizontal-screen-medium:                     null;
+@form-control-mini-add-on-padding-horizontal-screen-large:                      null;
 @form-control-mini-add-on-padding-horizontal-screen-jumbo:                      null;
 
 /* Margin */
@@ -151,16 +151,16 @@
 
 @form-control-mini-padding-left:                                                0.5rem;
 @form-control-mini-padding-left-screen-small:                                   null;
-@form-control-mini-padding-left-screen-medium:                                  1.1 * @form-control-mini-padding-left;
-@form-control-mini-padding-left-screen-large:                                   1.2 * @form-control-mini-padding-left;
+@form-control-mini-padding-left-screen-medium:                                  null;
+@form-control-mini-padding-left-screen-large:                                   null;
 @form-control-mini-padding-left-screen-jumbo:                                   null;
 
 // Padding Right
 
 @form-control-mini-padding-right:                                               0.5rem;
 @form-control-mini-padding-right-screen-small:                                  null;
-@form-control-mini-padding-right-screen-medium:                                 1.1 * @form-control-mini-padding-right;
-@form-control-mini-padding-right-screen-large:                                  1.2 * @form-control-mini-padding-right;
+@form-control-mini-padding-right-screen-medium:                                 null;
+@form-control-mini-padding-right-screen-large:                                  null;
 @form-control-mini-padding-right-screen-jumbo:                                  null;
 
 /* Rounded form-control */

--- a/styles/components/form/form-control/shapes/form-control-small/styles.less
+++ b/styles/components/form/form-control/shapes/form-control-small/styles.less
@@ -51,8 +51,8 @@
 
     &:after {
 
-      .property-variant(form-control-small, margin-left, null);
-      .property-variant(form-control-small, margin-top, null);
+      .property-variant(form-control-small-caret, margin-left, null);
+      .property-variant(form-control-small-caret, margin-top, null);
       .property-variant(form-control-small, margin-right, padding-right, null, null);
 
       & when not (@form-control-small-caret-width = null) {

--- a/styles/components/form/form-control/shapes/form-control-small/variables.less
+++ b/styles/components/form/form-control/shapes/form-control-small/variables.less
@@ -41,15 +41,15 @@
 
 // Height
 
-@form-control-small-height:                                                     32px;
+@form-control-small-height:                                                     30px;
 @form-control-small-height-screen-small:                                        null;
-@form-control-small-height-screen-medium:                                       1.1 * @form-control-small-height;
-@form-control-small-height-screen-large:                                        1.2 * @form-control-small-height;
+@form-control-small-height-screen-medium:                                       null;
+@form-control-small-height-screen-large:                                        32px;
 @form-control-small-height-screen-jumbo:                                        null;
 
 // Border Radius
 
-@form-control-small-border-radius:                                              4px;
+@form-control-small-border-radius:                                              3px;
 @form-control-small-border-radius-screen-small:                                 null;
 @form-control-small-border-radius-screen-medium:                                null;
 @form-control-small-border-radius-screen-large:                                 null;
@@ -59,16 +59,16 @@
 
 @form-control-small-caret-width:                                                9px * (@form-control-small-height / @form-control-height);
 @form-control-small-caret-width-screen-small:                                   null;
-@form-control-small-caret-width-screen-medium:                                  1.1 * @form-control-small-caret-width;
-@form-control-small-caret-width-screen-large:                                   1.2 * @form-control-small-caret-width;
+@form-control-small-caret-width-screen-medium:                                  null;
+@form-control-small-caret-width-screen-large:                                   1.1 * @form-control-small-caret-width;
 @form-control-small-caret-width-screen-jumbo:                                   null;
 
 // Dropdown Caret Height
 
 @form-control-small-caret-height:                                               5px * (@form-control-small-height / @form-control-height);
 @form-control-small-caret-height-screen-small:                                  null;
-@form-control-small-caret-height-screen-medium:                                 1.1 * @form-control-small-caret-height;
-@form-control-small-caret-height-screen-large:                                  1.2 * @form-control-small-caret-height;
+@form-control-small-caret-height-screen-medium:                                 null;
+@form-control-small-caret-height-screen-large:                                  1.1 * @form-control-small-caret-height;
 @form-control-small-caret-height-screen-jumbo:                                  null;
 
 // Dropdown Caret Margin Top
@@ -81,18 +81,18 @@
 
 // Dropdown Caret Margin Left
 
-@form-control-small-caret-margin-left:                                          0.75rem * 0.25;
+@form-control-small-caret-margin-left:                                          0.9rem * 0.25;
 @form-control-small-caret-margin-left-screen-small:                             null;
-@form-control-small-caret-margin-left-screen-medium:                            1.1 * @form-control-small-caret-margin-left;
-@form-control-small-caret-margin-left-screen-large:                             1.2 * @form-control-small-caret-margin-left;
+@form-control-small-caret-margin-left-screen-medium:                            null;
+@form-control-small-caret-margin-left-screen-large:                             null;
 @form-control-small-caret-margin-left-screen-jumbo:                             null;
 
 // Form Control Group Add On Padding Horizontal
 
-@form-control-small-add-on-padding-horizontal:                                  0.75rem * 0.5;
+@form-control-small-add-on-padding-horizontal:                                  0.9rem * 0.5;
 @form-control-small-add-on-padding-horizontal-screen-small:                     null;
-@form-control-small-add-on-padding-horizontal-screen-medium:                    1.1 * @form-control-small-add-on-padding-horizontal;
-@form-control-small-add-on-padding-horizontal-screen-large:                     1.2 * @form-control-small-add-on-padding-horizontal;
+@form-control-small-add-on-padding-horizontal-screen-medium:                    null;
+@form-control-small-add-on-padding-horizontal-screen-large:                     null;
 @form-control-small-add-on-padding-horizontal-screen-jumbo:                     null;
 
 /* Margin */
@@ -149,18 +149,18 @@
 
 // Padding Left
 
-@form-control-small-padding-left:                                               0.75rem;
+@form-control-small-padding-left:                                               0.9rem;
 @form-control-small-padding-left-screen-small:                                  null;
-@form-control-small-padding-left-screen-medium:                                 1.1 * @form-control-small-padding-left;
-@form-control-small-padding-left-screen-large:                                  1.2 * @form-control-small-padding-left;
+@form-control-small-padding-left-screen-medium:                                 null;
+@form-control-small-padding-left-screen-large:                                  null;
 @form-control-small-padding-left-screen-jumbo:                                  null;
 
 // Padding Right
 
-@form-control-small-padding-right:                                              0.75rem;
+@form-control-small-padding-right:                                              0.9rem;
 @form-control-small-padding-right-screen-small:                                 null;
-@form-control-small-padding-right-screen-medium:                                1.1 * @form-control-small-padding-right;
-@form-control-small-padding-right-screen-large:                                 1.2 * @form-control-small-padding-right;
+@form-control-small-padding-right-screen-medium:                                null;
+@form-control-small-padding-right-screen-large:                                 null;
 @form-control-small-padding-right-screen-jumbo:                                 null;
 
 /* Rounded form-control */

--- a/styles/components/form/form-control/styles.less
+++ b/styles/components/form/form-control/styles.less
@@ -268,9 +268,9 @@
       vertical-align: middle;
       .triangle-base();
       .triangle-color("down", @form-control-color);
-      .property-variant(form-control, margin-top, null);
-      .property-variant(form-control, margin-right, null);
-      .property-variant(form-control, margin-left, null);
+      .property-variant(form-control, margin-right, padding-right, null, null);
+      .property-variant(form-control-caret, margin-top, null);
+      .property-variant(form-control-caret, margin-left, null);
 
       & when not (@form-control-caret-width = null) {
 
@@ -621,9 +621,9 @@
 
         &:after {
 
+          .property-variant(form-control, margin-right, padding-right, null, screen-small);
           .property-variant(form-control-caret, margin-top, screen-small);
           .property-variant(form-control-caret, margin-left, screen-small);
-          .property-variant(form-control, margin-right, padding-right, null, screen-small);
 
           & when not (@form-control-caret-width = null) and not (@form-control-caret-width-screen-small = null) {
 
@@ -789,9 +789,9 @@
 
         select {
 
-          .element-text-size(form-control, screen-medium);
-          .element-spacing(form-control, null, screen-medium);
-          .property-variant(form-control, height, screen-medium);
+          .property-variant(form-control, margin-right, padding-right, null, screen-medium);
+          .property-variant(form-control-caret, margin-top, screen-medium);
+          .property-variant(form-control-caret, margin-left, screen-medium);
 
         }
 
@@ -977,9 +977,9 @@
 
         &:after {
 
+          .property-variant(form-control, margin-right, padding-right, null, screen-large);
           .property-variant(form-control-caret, margin-top, screen-large);
           .property-variant(form-control-caret, margin-left, screen-large);
-          .property-variant(form-control, margin-right, padding-right, null, screen-large);
 
           & when not (@form-control-caret-width = null) and not (@form-control-caret-width-screen-large = null) {
 
@@ -1155,9 +1155,9 @@
 
         &:after {
 
+          .property-variant(form-control, margin-right, padding-right, null, screen-jumbo);
           .property-variant(form-control-caret, margin-top, screen-jumbo);
           .property-variant(form-control-caret, margin-left, screen-jumbo);
-          .property-variant(form-control, margin-right, padding-right, null, screen-jumbo);
 
           & when not (@form-control-caret-width = null) and not (@form-control-caret-width-screen-jumbo = null) {
 

--- a/styles/components/form/form-control/styles/form-control-error/variables.less
+++ b/styles/components/form/form-control/styles/form-control-error/variables.less
@@ -22,7 +22,7 @@
 @form-control-error-background-gradient-color-top:                              null;
 @form-control-error-background-gradient-color-bottom:                           null;
 @form-control-error-border-width:                                               null;
-@form-control-error-border-color:                                               null;
+@form-control-error-border-color:                                               color-lighten(@red, 90);
 @form-control-error-border-style:                                               null;
 @form-control-error-border-top-width:                                           null;
 @form-control-error-border-top-color:                                           null;
@@ -84,7 +84,7 @@
 @form-control-error-active-background-gradient-color-top:                       null;
 @form-control-error-active-background-gradient-color-bottom:                    null;
 @form-control-error-active-border-width:                                        null;
-@form-control-error-active-border-color:                                        null;
+@form-control-error-active-border-color:                                        color-lighten(@red, 85);
 @form-control-error-active-border-style:                                        null;
 @form-control-error-active-border-top-width:                                    null;
 @form-control-error-active-border-top-color:                                    null;
@@ -176,11 +176,11 @@
 @form-control-error-inverse-text-shadow:                                        null;
 @form-control-error-inverse-text-decoration:                                    null;
 @form-control-error-inverse-text-rendering:                                     null;
-@form-control-error-inverse-background-color:                                   hsla(hue(color-lighten(@red, 0)), saturation(color-lighten(@red, 0)), lightness(color-lighten(@red, 0)), 0.25);
+@form-control-error-inverse-background-color:                                   color-lighten(@red, 0);
 @form-control-error-inverse-background-gradient-color-top:                      null;
 @form-control-error-inverse-background-gradient-color-bottom:                   null;
 @form-control-error-inverse-border-width:                                       null;
-@form-control-error-inverse-border-color:                                       null;
+@form-control-error-inverse-border-color:                                       color-lighten(@red, 0);
 @form-control-error-inverse-border-style:                                       null;
 @form-control-error-inverse-border-top-width:                                   null;
 @form-control-error-inverse-border-top-color:                                   null;
@@ -195,7 +195,7 @@
 @form-control-error-inverse-border-left-color:                                  null;
 @form-control-error-inverse-border-left-style:                                  null;
 @form-control-error-inverse-shadow:                                             null;
-@form-control-error-inverse-placeholder-color:                                  null;
+@form-control-error-inverse-placeholder-color:                                  color-lighten(@red, 60);
 
 // Hover
 
@@ -238,11 +238,11 @@
 @form-control-error-inverse-active-text-shadow:                                 null;
 @form-control-error-inverse-active-text-decoration:                             null;
 @form-control-error-inverse-active-text-rendering:                              null;
-@form-control-error-inverse-active-background-color:                            hsla(hue(color-lighten(@red, 0)), saturation(color-lighten(@red, 0)), lightness(color-lighten(@red, 0)), 0.35);
+@form-control-error-inverse-active-background-color:                            color-lighten(@red, 10);
 @form-control-error-inverse-active-background-gradient-color-top:               null;
 @form-control-error-inverse-active-background-gradient-color-bottom:            null;
 @form-control-error-inverse-active-border-width:                                null;
-@form-control-error-inverse-active-border-color:                                null;
+@form-control-error-inverse-active-border-color:                                color-lighten(@red, 10);
 @form-control-error-inverse-active-border-style:                                null;
 @form-control-error-inverse-active-border-top-width:                            null;
 @form-control-error-inverse-active-border-top-color:                            null;

--- a/styles/components/form/form-control/styles/form-control-success/variables.less
+++ b/styles/components/form/form-control/styles/form-control-success/variables.less
@@ -22,7 +22,7 @@
 @form-control-success-background-gradient-color-top:                            null;
 @form-control-success-background-gradient-color-bottom:                         null;
 @form-control-success-border-width:                                             null;
-@form-control-success-border-color:                                             null;
+@form-control-success-border-color:                                             color-lighten(@green, 90);
 @form-control-success-border-style:                                             null;
 @form-control-success-border-top-width:                                         null;
 @form-control-success-border-top-color:                                         null;
@@ -84,7 +84,7 @@
 @form-control-success-active-background-gradient-color-top:                     null;
 @form-control-success-active-background-gradient-color-bottom:                  null;
 @form-control-success-active-border-width:                                      null;
-@form-control-success-active-border-color:                                      null;
+@form-control-success-active-border-color:                                      color-lighten(@green, 85);
 @form-control-success-active-border-style:                                      null;
 @form-control-success-active-border-top-width:                                  null;
 @form-control-success-active-border-top-color:                                  null;
@@ -176,11 +176,11 @@
 @form-control-success-inverse-text-shadow:                                      null;
 @form-control-success-inverse-text-decoration:                                  null;
 @form-control-success-inverse-text-rendering:                                   null;
-@form-control-success-inverse-background-color:                                 hsla(hue(color-lighten(@green, 0)), saturation(color-lighten(@green, 0)), lightness(color-lighten(@green, 0)), 0.25);
+@form-control-success-inverse-background-color:                                 color-lighten(@green, 0);
 @form-control-success-inverse-background-gradient-color-top:                    null;
 @form-control-success-inverse-background-gradient-color-bottom:                 null;
 @form-control-success-inverse-border-width:                                     null;
-@form-control-success-inverse-border-color:                                     null;
+@form-control-success-inverse-border-color:                                     color-lighten(@green, 0);
 @form-control-success-inverse-border-style:                                     null;
 @form-control-success-inverse-border-top-width:                                 null;
 @form-control-success-inverse-border-top-color:                                 null;
@@ -195,7 +195,7 @@
 @form-control-success-inverse-border-left-color:                                null;
 @form-control-success-inverse-border-left-style:                                null;
 @form-control-success-inverse-shadow:                                           null;
-@form-control-success-inverse-placeholder-color:                                null;
+@form-control-success-inverse-placeholder-color:                                color-lighten(@green, 60);
 
 // Hover
 
@@ -238,11 +238,11 @@
 @form-control-success-inverse-active-text-shadow:                               null;
 @form-control-success-inverse-active-text-decoration:                           null;
 @form-control-success-inverse-active-text-rendering:                            null;
-@form-control-success-inverse-active-background-color:                          hsla(hue(color-lighten(@green, 0)), saturation(color-lighten(@green, 0)), lightness(color-lighten(@green, 0)), 0.35);
+@form-control-success-inverse-active-background-color:                          color-lighten(@green, 10);
 @form-control-success-inverse-active-background-gradient-color-top:             null;
 @form-control-success-inverse-active-background-gradient-color-bottom:          null;
 @form-control-success-inverse-active-border-width:                              null;
-@form-control-success-inverse-active-border-color:                              null;
+@form-control-success-inverse-active-border-color:                              color-lighten(@green, 10);
 @form-control-success-inverse-active-border-style:                              null;
 @form-control-success-inverse-active-border-top-width:                          null;
 @form-control-success-inverse-active-border-top-color:                          null;

--- a/styles/components/form/form-control/variables.less
+++ b/styles/components/form/form-control/variables.less
@@ -32,9 +32,9 @@
 @form-control-background-color:                                                 color-lighten(@neutral, 96);
 @form-control-background-gradient-color-top:                                    null;
 @form-control-background-gradient-color-bottom:                                 null;
-@form-control-border-width:                                                     0px;
-@form-control-border-color:                                                     null;
-@form-control-border-style:                                                     null;
+@form-control-border-width:                                                     1px;
+@form-control-border-color:                                                     color-lighten(@neutral, 96);
+@form-control-border-style:                                                     solid;
 @form-control-border-top-width:                                                 null;
 @form-control-border-top-color:                                                 null;
 @form-control-border-top-style:                                                 null;
@@ -95,7 +95,7 @@
 @form-control-active-background-gradient-color-top:                             null;
 @form-control-active-background-gradient-color-bottom:                          null;
 @form-control-active-border-width:                                              null;
-@form-control-active-border-color:                                              null;
+@form-control-active-border-color:                                              color-lighten(@neutral, 92);
 @form-control-active-border-style:                                              null;
 @form-control-active-border-top-width:                                          null;
 @form-control-active-border-top-color:                                          null;
@@ -191,7 +191,7 @@
 @form-control-inverse-background-gradient-color-top:                            null;
 @form-control-inverse-background-gradient-color-bottom:                         null;
 @form-control-inverse-border-width:                                             null;
-@form-control-inverse-border-color:                                             null;
+@form-control-inverse-border-color:                                             color-lighten(@neutral, 5);
 @form-control-inverse-border-style:                                             null;
 @form-control-inverse-border-top-width:                                         null;
 @form-control-inverse-border-top-color:                                         null;
@@ -253,7 +253,7 @@
 @form-control-inverse-active-background-gradient-color-top:                     null;
 @form-control-inverse-active-background-gradient-color-bottom:                  null;
 @form-control-inverse-active-border-width:                                      null;
-@form-control-inverse-active-border-color:                                      null;
+@form-control-inverse-active-border-color:                                      color-lighten(@neutral, 15);
 @form-control-inverse-active-border-style:                                      null;
 @form-control-inverse-active-border-top-width:                                  null;
 @form-control-inverse-active-border-top-color:                                  null;
@@ -341,10 +341,10 @@
 
 // Font Size
 
-@form-control-font-size:                                                        1.0rem;
+@form-control-font-size:                                                        14px;
 @form-control-font-size-screen-small:                                           null;
 @form-control-font-size-screen-medium:                                          null;
-@form-control-font-size-screen-large:                                           null;
+@form-control-font-size-screen-large:                                           15px;
 @form-control-font-size-screen-jumbo:                                           null;
 
 // Line Height
@@ -363,15 +363,15 @@
 
 // Height
 
-@form-control-height:                                                           38px;
+@form-control-height:                                                           36px;
 @form-control-height-screen-small:                                              null;
-@form-control-height-screen-medium:                                             1.1 * @form-control-height;
-@form-control-height-screen-large:                                              1.2 * @form-control-height;
+@form-control-height-screen-medium:                                             null;
+@form-control-height-screen-large:                                              38px;
 @form-control-height-screen-jumbo:                                              null;
 
 // Border Radius
 
-@form-control-border-radius:                                                    5px;
+@form-control-border-radius:                                                    4px;
 @form-control-border-radius-screen-small:                                       null;
 @form-control-border-radius-screen-medium:                                      null;
 @form-control-border-radius-screen-large:                                       null;
@@ -381,16 +381,16 @@
 
 @form-control-caret-width:                                                      9px;
 @form-control-caret-width-screen-small:                                         null;
-@form-control-caret-width-screen-medium:                                        1.1 * @form-control-caret-width;
-@form-control-caret-width-screen-large:                                         1.2 * @form-control-caret-width;
+@form-control-caret-width-screen-medium:                                        null;
+@form-control-caret-width-screen-large:                                         1.1 * @form-control-caret-width;
 @form-control-caret-width-screen-jumbo:                                         null;
 
 // Dropdown Caret Height
 
 @form-control-caret-height:                                                     5px;
 @form-control-caret-height-screen-small:                                        null;
-@form-control-caret-height-screen-medium:                                       1.1 * @form-control-caret-height;
-@form-control-caret-height-screen-large:                                        1.2 * @form-control-caret-height;
+@form-control-caret-height-screen-medium:                                       null;
+@form-control-caret-height-screen-large:                                        1.1 * @form-control-caret-height;
 @form-control-caret-height-screen-jumbo:                                        null;
 
 // Dropdown Caret Margin Top
@@ -403,18 +403,18 @@
 
 // Dropdown Caret Margin Left
 
-@form-control-caret-margin-left:                                                1.5rem * 0.25;
+@form-control-caret-margin-left:                                                1.0rem * 0.5;
 @form-control-caret-margin-left-screen-small:                                   null;
-@form-control-caret-margin-left-screen-medium:                                  1.1 * @form-control-caret-margin-left;
-@form-control-caret-margin-left-screen-large:                                   1.2 * @form-control-caret-margin-left;
+@form-control-caret-margin-left-screen-medium:                                  null;
+@form-control-caret-margin-left-screen-large:                                   null;
 @form-control-caret-margin-left-screen-jumbo:                                   null;
 
 // Form Control Group Add On Padding Horizontal
 
 @form-control-add-on-padding-horizontal:                                        1.0rem * 0.5;
 @form-control-add-on-padding-horizontal-screen-small:                           null;
-@form-control-add-on-padding-horizontal-screen-medium:                          1.1 * @form-control-add-on-padding-horizontal;
-@form-control-add-on-padding-horizontal-screen-large:                           1.2 * @form-control-add-on-padding-horizontal;
+@form-control-add-on-padding-horizontal-screen-medium:                          null;
+@form-control-add-on-padding-horizontal-screen-large:                           null;
 @form-control-add-on-padding-horizontal-screen-jumbo:                           null;
 
 /* Margin */
@@ -473,16 +473,16 @@
 
 @form-control-padding-left:                                                     1.0rem;
 @form-control-padding-left-screen-small:                                        null;
-@form-control-padding-left-screen-medium:                                       1.1 * @form-control-padding-left;
-@form-control-padding-left-screen-large:                                        1.2 * @form-control-padding-left;
+@form-control-padding-left-screen-medium:                                       null;
+@form-control-padding-left-screen-large:                                        null;
 @form-control-padding-left-screen-jumbo:                                        null;
 
 // Padding Right
 
 @form-control-padding-right:                                                    1.0rem;
 @form-control-padding-right-screen-small:                                       null;
-@form-control-padding-right-screen-medium:                                      1.1 * @form-control-padding-right;
-@form-control-padding-right-screen-large:                                       1.2 * @form-control-padding-right;
+@form-control-padding-right-screen-medium:                                      null;
+@form-control-padding-right-screen-large:                                       null;
 @form-control-padding-right-screen-jumbo:                                       null;
 
 /* Rounded form-control */

--- a/styles/components/form/form-control/variables.less
+++ b/styles/components/form/form-control/variables.less
@@ -403,7 +403,7 @@
 
 // Dropdown Caret Margin Left
 
-@form-control-caret-margin-left:                                                1.0rem * 0.5;
+@form-control-caret-margin-left:                                                1.0rem * 0.25;
 @form-control-caret-margin-left-screen-small:                                   null;
 @form-control-caret-margin-left-screen-medium:                                  null;
 @form-control-caret-margin-left-screen-large:                                   null;


### PR DESCRIPTION
Dependent on this PR https://github.com/mesosphere/canvas/pull/35
- Made `.panel` examples in Docs wider.
- Darkened the background of the `.panel-inverse` example block, because we are using the `.panel` object for these example blocks, resulting in the panel being invisible.
