### PR TITLE
Change modal dividers to borders instead of box-shadows

### DIFF
--- a/styles/components/modal/variables.less
+++ b/styles/components/modal/variables.less
@@ -179,13 +179,13 @@
 @modal-header-border-right-width:                                               null;
 @modal-header-border-right-color:                                               null;
 @modal-header-border-right-style:                                               null;
-@modal-header-border-bottom-width:                                              null;
-@modal-header-border-bottom-color:                                              null;
-@modal-header-border-bottom-style:                                              null;
+@modal-header-border-bottom-width:                                              1px;
+@modal-header-border-bottom-color:                                              rgba(0, 0, 0, 0.1);
+@modal-header-border-bottom-style:                                              solid;
 @modal-header-border-left-width:                                                null;
 @modal-header-border-left-color:                                                null;
 @modal-header-border-left-style:                                                null;
-@modal-header-shadow:                                                           0 0 0 1px rgba(0, 0, 0, 0.1);
+@modal-header-shadow:                                                           null;
 
 // Inverse
 
@@ -301,7 +301,7 @@
 @modal-body-border-left-width:                                                  null;
 @modal-body-border-left-color:                                                  null;
 @modal-body-border-left-style:                                                  null;
-@modal-body-shadow:                                                             0 0 0 1px rgba(0, 0, 0, 0.1);
+@modal-body-shadow:                                                             null;
 
 // Inverse
 
@@ -405,9 +405,9 @@
 @modal-footer-border-width:                                                     null;
 @modal-footer-border-color:                                                     null;
 @modal-footer-border-style:                                                     null;
-@modal-footer-border-top-width:                                                 null;
-@modal-footer-border-top-color:                                                 null;
-@modal-footer-border-top-style:                                                 null;
+@modal-footer-border-top-width:                                                 1px;
+@modal-footer-border-top-color:                                                 rgba(0, 0, 0, 0.1);
+@modal-footer-border-top-style:                                                 solid;
 @modal-footer-border-right-width:                                               null;
 @modal-footer-border-right-color:                                               null;
 @modal-footer-border-right-style:                                               null;
@@ -417,7 +417,7 @@
 @modal-footer-border-left-width:                                                null;
 @modal-footer-border-left-color:                                                null;
 @modal-footer-border-left-style:                                                null;
-@modal-footer-shadow:                                                           0 0 0 1px rgba(0, 0, 0, 0.1);
+@modal-footer-shadow:                                                           null;
 
 // Inverse
 


### PR DESCRIPTION
This PR changes the visual separator from `box-shadow`s to `border`s, because `box-shadow` can be invisible when users are zoomed out.

Previously, the shadow used the spread radius value and spread out in all directions. It was applied to `modal-header`, `-body`, and `-footer`, meaning the body shadow overlapped the header and footer shadow. In this PR, the borders are applied to the bottom of `modal-header` and the top of `modal-footer` so there won't be any overlap.