### PR TITLE
Add .wrap for .code-block and pre elements

### DIFF
--- a/styles/content/code/code-block/styles.less
+++ b/styles/content/code/code-block/styles.less
@@ -32,6 +32,10 @@
       background: none !important;
     }
 
+    &.wrap {
+      white-space: pre-wrap;
+    }
+
     /* Code Block Inverse (.code-block-inverse) */
 
     &.code-block-inverse {


### PR DESCRIPTION
In some cases we need to wrap these elements, for instance: ![](https://cl.ly/2X1Z193Z3G2F/Screen%20Shot%202016-11-02%20at%201.17.47%20PM.png)