### PR TITLE
Updated Table Styles

### DIFF
--- a/docs/_includes/content/tables/tables-flush.html
+++ b/docs/_includes/content/tables/tables-flush.html
@@ -1,0 +1,201 @@
+<!-- =================================================
+BEGIN: Tables Flush
+================================================== -->
+
+<section id="tables-flush">
+
+  <h2>
+
+    Flush Tables
+
+  </h2>
+
+  <p>
+
+    Add <code>.table-flush</code> to remove the horizontal padding applied to the first and last cell of a table row.
+
+  </p>
+
+  <!-- =================================================
+  BEGIN: Example
+  ================================================== -->
+
+  <div class="panel flush-bottom">
+
+    <div class="panel-cell">
+
+      <table class="table table-flush table-borderless-outer table-borderless-inner-columns flush-bottom">
+
+        <thead>
+
+          <tr>
+
+            <th>
+
+              First Name
+
+            </th>
+
+            <th>
+
+              Last Name
+
+            </th>
+
+            <th class="active">
+
+              Email
+
+            </th>
+
+            <th>
+
+              Commits
+
+            </th>
+
+          </tr>
+
+        </thead>
+
+        <tbody>
+
+          <tr>
+
+            <td>
+
+              John
+
+            </td>
+
+            <td>
+
+              Ashenden
+
+            </td>
+
+            <td class="active">
+
+              john.ashenden@domain.com
+
+            </td>
+
+            <td>
+
+              802
+
+            </td>
+
+          </tr>
+
+          <tr class="">
+
+            <td>
+
+              Michael
+
+            </td>
+
+            <td>
+
+              Lunøe
+
+            </td>
+
+            <td class="active">
+
+              michael.lunoe@domain.com
+
+            </td>
+
+            <td>
+
+              2,401
+
+            </td>
+
+          </tr>
+
+          <tr>
+
+            <td>
+
+              Rafael
+
+            </td>
+
+            <td>
+
+              Corral
+
+            </td>
+
+            <td class="active">
+
+              rafael.corral@domain.com
+
+            </td>
+
+            <td>
+
+              1,532
+
+            </td>
+
+          </tr>
+
+          <tr>
+
+            <td>
+
+              Jesse
+
+            </td>
+
+            <td>
+
+              Lash
+
+            </td>
+
+            <td class="active">
+
+              jesse.lash@domain.com
+
+            </td>
+
+            <td>
+
+              104
+
+            </td>
+
+          </tr>
+
+        </tbody>
+
+      </table>
+
+    </div>
+
+    <div class="panel-cell panel-cell-light panel-cell-code-block">
+
+<pre class="prettyprint transparent flush lang-html">
+&lt;table class="table table-flush table-borderless-outer table-borderless-inner-columns"&gt;
+  &hellip;
+&lt;/table&gt;
+</pre>
+
+    </div>
+
+  </div>
+
+  <!-- =================================================
+  END: Example
+  ================================================== -->
+
+</section>
+
+<!-- =================================================
+END: Tables Flush
+================================================== -->

--- a/docs/content/tables/index.html
+++ b/docs/content/tables/index.html
@@ -12,6 +12,8 @@ page-navigation:
   link: "#tables-hover-rows"
 - label: "Borderless Tables"
   link: "#tables-borderless"
+- label: "Flush Tables"
+  link: "#tables-flush"
 - label: "Conditional Row States"
   link: "#tables-conditional-row-states"
 - label: "Inverse Styling"
@@ -237,6 +239,7 @@ BEGIN: Tables
 
     {% include content/tables/tables-hover-rows.html %}
     {% include content/tables/tables-borderless.html %}
+    {% include content/tables/tables-flush.html %}
     {% include content/tables/tables-conditional-row-states.html %}
     {% include content/tables/tables-inverse.html %}
     {% include content/tables/tables-sizes.html %}

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "description": "Canvas is a system of user interface elements and components for use across Mesosphere sites and products. Canvas defines stylistic guidelines for the design and structure of digital interfaces in an effort to ensure consistency in brand and interaction.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "predist": "rm -rf dist",
-    "prewatch": "rm -rf docs/dist",
     "dist": "gulp canvas:build",
-    "predocs-dist": "rm -rf docs/dist",
     "docs-dist": "gulp docs:build --production",
+    "predist": "rm -rf dist",
+    "predocs-dist": "rm -rf docs/dist",
+    "prewatch": "rm -rf docs/dist",
+    "start": "gulp",
+    "test": "echo \"Error: no test specified\" && exit 1",
     "watch": "gulp watch"
   },
   "repository": {

--- a/styles/components/form/label/variables.less
+++ b/styles/components/form/label/variables.less
@@ -96,18 +96,18 @@
 
 // Font Size
 
-@label-font-size: 0.8rem;
+@label-font-size: 0.9rem;
 @label-font-size-screen-small: null;
-@label-font-size-screen-medium: 1.05 * @label-font-size;
-@label-font-size-screen-large: 1.1 * @label-font-size;
+@label-font-size-screen-medium: null;
+@label-font-size-screen-large: null;
 @label-font-size-screen-jumbo: null;
 
 // Line Height
 
-@label-line-height: 0.8rem;
+@label-line-height: @label-font-size * 1.3;
 @label-line-height-screen-small: null;
-@label-line-height-screen-medium: 1.05 * @label-line-height;
-@label-line-height-screen-large: 1.1 * @label-line-height;
+@label-line-height-screen-medium: null;
+@label-line-height-screen-large: null;
 @label-line-height-screen-jumbo: null;
 
 /*

--- a/styles/content/table/shapes/table-large/styles.less
+++ b/styles/content/table/shapes/table-large/styles.less
@@ -104,15 +104,12 @@
 
     // Table Head
 
-    thead {
+    th {
+      .element-text-size(table-large-header, null);
+      .element-spacing(table-large-header, null, null);
 
-      th {
-        .element-text-size(table-large-header, null);
-        .element-spacing(table-large-header, null, null);
-
-        &:before {
-          .property-variant(table-large-header, height, line-height, null, null);
-        }
+      &:before {
+        .property-variant(table-large-header, height, line-height, null, null);
       }
     }
   }
@@ -146,6 +143,17 @@
 
           &:before {
             .property-variant(table-large-cell, height, line-height, null, screen-small);
+          }
+        }
+
+        // Table Head
+
+        th {
+          .element-text-size(table-large-header, screen-small);
+          .element-spacing(table-large-header, null, screen-small);
+
+          &:before {
+            .property-variant(table-large-header, height, line-height, null, screen-small);
           }
         }
       }
@@ -183,6 +191,17 @@
             .property-variant(table-large-cell, height, line-height, null, screen-medium);
           }
         }
+
+        // Table Head
+
+        th {
+          .element-text-size(table-large-header, screen-medium);
+          .element-spacing(table-large-header, null, screen-medium);
+
+          &:before {
+            .property-variant(table-large-header, height, line-height, null, screen-medium);
+          }
+        }
       }
     }
   }
@@ -218,6 +237,17 @@
             .property-variant(table-large-cell, height, line-height, null, screen-large);
           }
         }
+
+        // Table Head
+
+        th {
+          .element-text-size(table-large-header, screen-large);
+          .element-spacing(table-large-header, null, screen-large);
+
+          &:before {
+            .property-variant(table-large-header, height, line-height, null, screen-large);
+          }
+        }
       }
     }
   }
@@ -251,6 +281,17 @@
 
           &:before {
             .property-variant(table-large-cell, height, line-height, null, screen-jumbo);
+          }
+        }
+
+        // Table Head
+
+        th {
+          .element-text-size(table-large-header, screen-jumbo);
+          .element-spacing(table-large-header, null, screen-jumbo);
+
+          &:before {
+            .property-variant(table-large-header, height, line-height, null, screen-jumbo);
           }
         }
       }

--- a/styles/content/table/shapes/table-large/styles.less
+++ b/styles/content/table/shapes/table-large/styles.less
@@ -56,7 +56,7 @@
         }
       }
 
-      > thead {
+      & > thead {
 
         tr {
 
@@ -75,7 +75,7 @@
           }
         }
 
-        + tbody {
+        & + tbody {
 
           tr {
 

--- a/styles/content/table/shapes/table-large/variables.less
+++ b/styles/content/table/shapes/table-large/variables.less
@@ -15,7 +15,7 @@
 
 // Font Size
 
-@table-large-font-size: null;
+@table-large-font-size: 1.1rem;
 @table-large-font-size-screen-small: null;
 @table-large-font-size-screen-medium: null;
 @table-large-font-size-screen-large: null;
@@ -23,7 +23,7 @@
 
 // Line Height
 
-@table-large-line-height: null;
+@table-large-line-height: @table-large-font-size * 1.1;
 @table-large-line-height-screen-small: null;
 @table-large-line-height-screen-medium: null;
 @table-large-line-height-screen-large: null;
@@ -37,7 +37,7 @@
 
 // Border Radius
 
-@table-large-border-radius: 3px;
+@table-large-border-radius: null;
 @table-large-border-radius-screen-small: null;
 @table-large-border-radius-screen-medium: null;
 @table-large-border-radius-screen-large: null;
@@ -143,7 +143,7 @@
 
 // Font Size
 
-@table-large-cell-font-size: 1.1rem;
+@table-large-cell-font-size: null;
 @table-large-cell-font-size-screen-small: null;
 @table-large-cell-font-size-screen-medium: null;
 @table-large-cell-font-size-screen-large: null;
@@ -151,7 +151,7 @@
 
 // Line Height
 
-@table-large-cell-line-height: @table-large-cell-font-size * 1.1;
+@table-large-cell-line-height: null;
 @table-large-cell-line-height-screen-small: null;
 @table-large-cell-line-height-screen-medium: null;
 @table-large-cell-line-height-screen-large: null;
@@ -231,7 +231,7 @@
 
 // Font Size
 
-@table-large-header-font-size: 1em;
+@table-large-header-font-size: 0.9em;
 @table-large-header-font-size-screen-small: null;
 @table-large-header-font-size-screen-medium: null;
 @table-large-header-font-size-screen-large: null;
@@ -239,7 +239,7 @@
 
 // Line Height
 
-@table-large-header-line-height: @table-large-header-font-size * 1.3;
+@table-large-header-line-height: null;
 @table-large-header-line-height-screen-small: null;
 @table-large-header-line-height-screen-medium: null;
 @table-large-header-line-height-screen-large: null;

--- a/styles/content/table/shapes/table-large/variables.less
+++ b/styles/content/table/shapes/table-large/variables.less
@@ -138,7 +138,7 @@
 @table-large-tall-padding-right-scale: null;
 
 /*
- * Tabel Cell Text Size
+ * Table Cell Text Size
  */
 
 // Font Size
@@ -226,7 +226,7 @@
 @table-large-cell-padding-right-screen-jumbo: null;
 
 /*
- * Tabel Header Text Size
+ * Table Header Text Size
  */
 
 // Font Size

--- a/styles/content/table/shapes/table-small/styles.less
+++ b/styles/content/table/shapes/table-small/styles.less
@@ -105,15 +105,12 @@
 
     // Table Head
 
-    thead {
+    th {
+      .element-text-size(table-small-header, null);
+      .element-spacing(table-small-header, null, null);
 
-      th {
-        .element-text-size(table-small-header, null);
-        .element-spacing(table-small-header, null, null);
-
-        &:before {
-          .property-variant(table-small-header, height, line-height, null, null);
-        }
+      &:before {
+        .property-variant(table-small-header, height, line-height, null, null);
       }
     }
   }
@@ -147,6 +144,17 @@
 
           &:before {
             .property-variant(table-small-cell, height, line-height, null, screen-small);
+          }
+        }
+
+        // Table Head
+
+        th {
+          .element-text-size(table-small-header, screen-small);
+          .element-spacing(table-small-header, null, screen-small);
+
+          &:before {
+            .property-variant(table-small-header, height, line-height, null, screen-small);
           }
         }
       }
@@ -184,6 +192,17 @@
             .property-variant(table-small-cell, height, line-height, null, screen-medium);
           }
         }
+
+        // Table Head
+
+        th {
+          .element-text-size(table-small-header, screen-medium);
+          .element-spacing(table-small-header, null, screen-medium);
+
+          &:before {
+            .property-variant(table-small-header, height, line-height, null, screen-medium);
+          }
+        }
       }
     }
   }
@@ -219,6 +238,17 @@
             .property-variant(table-small-cell, height, line-height, null, screen-large);
           }
         }
+
+        // Table Head
+
+        th {
+          .element-text-size(table-small-header, screen-large);
+          .element-spacing(table-small-header, null, screen-large);
+
+          &:before {
+            .property-variant(table-small-header, height, line-height, null, screen-large);
+          }
+        }
       }
     }
   }
@@ -252,6 +282,17 @@
 
           &:before {
             .property-variant(table-small-cell, height, line-height, null, screen-jumbo);
+          }
+        }
+
+        // Table Head
+
+        th {
+          .element-text-size(table-small-header, screen-jumbo);
+          .element-spacing(table-small-header, null, screen-jumbo);
+
+          &:before {
+            .property-variant(table-small-header, height, line-height, null, screen-jumbo);
           }
         }
       }

--- a/styles/content/table/shapes/table-small/styles.less
+++ b/styles/content/table/shapes/table-small/styles.less
@@ -56,7 +56,7 @@
         }
       }
 
-      > thead {
+      & > thead {
 
         tr {
 
@@ -75,7 +75,7 @@
           }
         }
 
-        + tbody {
+        & + tbody {
 
           tr {
 

--- a/styles/content/table/shapes/table-small/variables.less
+++ b/styles/content/table/shapes/table-small/variables.less
@@ -15,7 +15,7 @@
 
 // Font Size
 
-@table-small-font-size: null;
+@table-small-font-size: 0.9rem;
 @table-small-font-size-screen-small: null;
 @table-small-font-size-screen-medium: null;
 @table-small-font-size-screen-large: null;
@@ -23,7 +23,7 @@
 
 // Line Height
 
-@table-small-line-height: null;
+@table-small-line-height: @table-small-font-size * 1.2;
 @table-small-line-height-screen-small: null;
 @table-small-line-height-screen-medium: null;
 @table-small-line-height-screen-large: null;
@@ -37,7 +37,7 @@
 
 // Border Radius
 
-@table-small-border-radius: 3px;
+@table-small-border-radius: null;
 @table-small-border-radius-screen-small: null;
 @table-small-border-radius-screen-medium: null;
 @table-small-border-radius-screen-large: null;
@@ -143,7 +143,7 @@
 
 // Font Size
 
-@table-small-cell-font-size: 0.9rem;
+@table-small-cell-font-size: null;
 @table-small-cell-font-size-screen-small: null;
 @table-small-cell-font-size-screen-medium: null;
 @table-small-cell-font-size-screen-large: null;
@@ -151,7 +151,7 @@
 
 // Line Height
 
-@table-small-cell-line-height: @table-small-cell-font-size * 1.1;
+@table-small-cell-line-height: null;
 @table-small-cell-line-height-screen-small: null;
 @table-small-cell-line-height-screen-medium: null;
 @table-small-cell-line-height-screen-large: null;
@@ -231,7 +231,7 @@
 
 // Font Size
 
-@table-small-header-font-size: 0.85em;
+@table-small-header-font-size: 0.9em;
 @table-small-header-font-size-screen-small: null;
 @table-small-header-font-size-screen-medium: null;
 @table-small-header-font-size-screen-large: null;
@@ -239,7 +239,7 @@
 
 // Line Height
 
-@table-small-header-line-height: @table-small-header-font-size * 1.3;
+@table-small-header-line-height: null;
 @table-small-header-line-height-screen-small: null;
 @table-small-header-line-height-screen-medium: null;
 @table-small-header-line-height-screen-large: null;

--- a/styles/content/table/shapes/table-small/variables.less
+++ b/styles/content/table/shapes/table-small/variables.less
@@ -138,7 +138,7 @@
 @table-small-tall-padding-right-scale: null;
 
 /*
- * Tabel Cell Text Size
+ * Table Cell Text Size
  */
 
 // Font Size
@@ -226,7 +226,7 @@
 @table-small-cell-padding-right-screen-jumbo: null;
 
 /*
- * Tabel Header Text Size
+ * Table Header Text Size
  */
 
 // Font Size

--- a/styles/content/table/styles.less
+++ b/styles/content/table/styles.less
@@ -340,6 +340,26 @@
     width: 100%;
   }
 
+  /* Table Flush */
+
+  &.table-flush {
+
+    tr {
+
+      td,
+      th {
+
+        &:first-child {
+          padding-left: 0;
+        }
+
+        &:last-child {
+          padding-right: 0;
+        }
+      }
+    }
+  }
+
   /* Table Borderless */
 
   &.table-borderless {

--- a/styles/content/table/styles.less
+++ b/styles/content/table/styles.less
@@ -687,6 +687,10 @@
         th {
           .element-spacing(table-header, null, screen-small);
           .element-text-size(table-header, screen-small);
+
+          &:before {
+            .property-variant(table-header, height, line-height, null, screen-small);
+          }
         }
       }
     }
@@ -729,6 +733,10 @@
         th {
           .element-spacing(table-header, null, screen-medium);
           .element-text-size(table-header, screen-medium);
+
+          &:before {
+            .property-variant(table-header, height, line-height, null, screen-medium);
+          }
         }
       }
     }
@@ -771,6 +779,10 @@
         th {
           .element-spacing(table-header, null, screen-large);
           .element-text-size(table-header, screen-large);
+
+          &:before {
+            .property-variant(table-header, height, line-height, null, screen-large);
+          }
         }
       }
     }
@@ -813,6 +825,10 @@
         th {
           .element-spacing(table-header, null, screen-jumbo);
           .element-text-size(table-header, screen-jumbo);
+
+          &:before {
+            .property-variant(table-header, height, line-height, null, screen-jumbo);
+          }
         }
       }
     }

--- a/styles/content/table/styles.less
+++ b/styles/content/table/styles.less
@@ -59,7 +59,7 @@
         }
       }
 
-      > thead {
+      & > thead {
 
         tr {
 
@@ -78,7 +78,7 @@
           }
         }
 
-        + tbody {
+        & + tbody {
 
           tr {
 
@@ -350,7 +350,7 @@
 
   &.table-borderless {
 
-    > thead {
+    & > thead {
 
       tr {
 
@@ -360,8 +360,8 @@
       }
     }
 
-    > tbody,
-    > tfoot {
+    & > tbody,
+    & > tfoot {
 
       tr {
 
@@ -377,7 +377,7 @@
 
   &.table-borderless-outer {
 
-    > thead {
+    & > thead {
 
       tr {
 
@@ -408,8 +408,8 @@
       }
     }
 
-    > tbody,
-    > tfoot {
+    & > tbody,
+    & > tfoot {
 
       tr {
 
@@ -448,7 +448,7 @@
 
   &.table-borderless-outer-rows {
 
-    > thead {
+    & > thead {
 
       tr {
 
@@ -468,8 +468,8 @@
       }
     }
 
-    > tbody,
-    > tfoot {
+    & > tbody,
+    & > tfoot {
 
       tr {
 
@@ -496,7 +496,7 @@
 
   &.table-borderless-outer-columns {
 
-    > thead {
+    & > thead {
 
       tr {
 
@@ -513,8 +513,8 @@
       }
     }
 
-    > tbody,
-    > tfoot {
+    & > tbody,
+    & > tfoot {
 
       tr {
 
@@ -537,9 +537,9 @@
 
   &.table-borderless-inner {
 
-    > thead,
-    > tbody,
-    > tfoot {
+    & > thead,
+    & > tbody,
+    & > tfoot {
 
       tr {
 
@@ -573,7 +573,7 @@
       }
     }
 
-    > thead + tbody {
+    & > thead + tbody {
 
       tr {
 
@@ -592,9 +592,9 @@
 
   &.table-borderless-inner-rows {
 
-    > thead,
-    > tbody,
-    > tfoot {
+    & > thead,
+    & > tbody,
+    & > tfoot {
 
       tr {
 
@@ -617,7 +617,7 @@
     }
   }
 
-  > thead + tbody {
+  & > thead + tbody {
 
     tr {
 
@@ -635,9 +635,9 @@
 
   &.table-borderless-inner-columns {
 
-    > thead,
-    > tbody,
-    > tfoot {
+    & > thead,
+    & > tbody,
+    & > tfoot {
 
       tr {
 

--- a/styles/content/table/styles.less
+++ b/styles/content/table/styles.less
@@ -391,7 +391,7 @@
         &:last-child {
 
           th {
-            border-bottom: 0;
+            //border-bottom: 0;
           }
         }
 

--- a/styles/content/table/styles.less
+++ b/styles/content/table/styles.less
@@ -148,50 +148,47 @@
 
     // Table Head
 
-    thead {
+    th {
+      .element-shape-style(table-header);
+      .element-spacing(table-header, null, null);
+      .element-text-size(table-header, null);
+      .element-text-style(table-header);
 
-      th {
-        .element-shape-style(table-header);
-        .element-spacing(table-header, null, null);
-        .element-text-size(table-header, null);
-        .element-text-style(table-header);
+      &:before {
+        .property-variant(table-header, height, line-height, null, null);
+      }
 
-        &:before {
-          .property-variant(table-header, height, line-height, null, null);
+      &.selectable {
+
+        &:hover {
+          .element-shape-style(table-header-hover);
+          .element-text-style(table-header-hover);
         }
+      }
+
+      &.disabled {
+        .element-shape-style(table-header-disabled);
+        .element-text-style(table-header-disabled);
+      }
+
+      // Cell Active
+
+      &.active,
+      &.highlight {
+        .element-shape-style(table-header-active);
+        .element-text-style(table-header-active);
 
         &.selectable {
 
           &:hover {
-            .element-shape-style(table-header-hover);
-            .element-text-style(table-header-hover);
+            .element-shape-style(table-header-active-hover);
+            .element-text-style(table-header-active-hover);
           }
         }
 
         &.disabled {
-          .element-shape-style(table-header-disabled);
-          .element-text-style(table-header-disabled);
-        }
-
-        // Cell Active
-
-        &.active,
-        &.highlight {
-          .element-shape-style(table-header-active);
-          .element-text-style(table-header-active);
-
-          &.selectable {
-
-            &:hover {
-              .element-shape-style(table-header-active-hover);
-              .element-text-style(table-header-active-hover);
-            }
-          }
-
-          &.disabled {
-            .element-shape-style(table-header-active-disabled);
-            .element-text-style(table-header-active-disabled);
-          }
+          .element-shape-style(table-header-active-disabled);
+          .element-text-style(table-header-active-disabled);
         }
       }
     }
@@ -269,44 +266,41 @@
 
       // Table Head
 
-      thead {
+      th {
+        .element-shape-style(table-header-inverse);
+        .element-text-style(table-header-inverse);
 
-        th {
-          .element-shape-style(table-header-inverse);
-          .element-text-style(table-header-inverse);
+        &.selectable {
+
+          &:hover {
+            .element-shape-style(table-header-inverse-hover);
+            .element-text-style(table-header-inverse-hover);
+          }
+        }
+
+        &.disabled {
+          .element-shape-style(table-header-inverse-disabled);
+          .element-text-style(table-header-inverse-disabled);
+        }
+
+        // Cell Active
+
+        &.active,
+        &.highlight {
+          .element-shape-style(table-header-inverse-active);
+          .element-text-style(table-header-inverse-active);
 
           &.selectable {
 
             &:hover {
-              .element-shape-style(table-header-inverse-hover);
-              .element-text-style(table-header-inverse-hover);
+              .element-text-style(table-header-inverse-active-hover);
+              .element-shape-style(table-header-inverse-active-hover);
             }
           }
 
           &.disabled {
-            .element-shape-style(table-header-inverse-disabled);
-            .element-text-style(table-header-inverse-disabled);
-          }
-
-          // Cell Active
-
-          &.active,
-          &.highlight {
-            .element-shape-style(table-header-inverse-active);
-            .element-text-style(table-header-inverse-active);
-
-            &.selectable {
-
-              &:hover {
-                .element-text-style(table-header-inverse-active-hover);
-                .element-shape-style(table-header-inverse-active-hover);
-              }
-            }
-
-            &.disabled {
-              .element-text-style(table-header-inverse-active-disabled);
-              .element-shape-style(table-header-inverse-active-disabled);
-            }
+            .element-text-style(table-header-inverse-active-disabled);
+            .element-shape-style(table-header-inverse-active-disabled);
           }
         }
       }
@@ -687,6 +681,13 @@
             .property-variant(table-cell, height, line-height, null, screen-small);
           }
         }
+
+        // Table Head
+
+        th {
+          .element-spacing(table-header, null, screen-small);
+          .element-text-size(table-header, screen-small);
+        }
       }
     }
   }
@@ -721,6 +722,13 @@
           &:before {
             .property-variant(table-cell, height, line-height, null, screen-medium);
           }
+        }
+
+        // Table Head
+
+        th {
+          .element-spacing(table-header, null, screen-medium);
+          .element-text-size(table-header, screen-medium);
         }
       }
     }
@@ -757,6 +765,13 @@
             .property-variant(table-cell, height, line-height, null, screen-large);
           }
         }
+
+        // Table Head
+
+        th {
+          .element-spacing(table-header, null, screen-large);
+          .element-text-size(table-header, screen-large);
+        }
       }
     }
   }
@@ -791,6 +806,13 @@
           &:before {
             .property-variant(table-cell, height, line-height, null, screen-jumbo);
           }
+        }
+
+        // Table Head
+
+        th {
+          .element-spacing(table-header, null, screen-jumbo);
+          .element-text-size(table-header, screen-jumbo);
         }
       }
     }

--- a/styles/content/table/styles/table-cell-danger/variables.less
+++ b/styles/content/table/styles/table-cell-danger/variables.less
@@ -1,7 +1,7 @@
 @table-cell-danger-enabled: @typography-enabled;
 
 /*
- * Tabel Cell Styling
+ * Table Cell Styling
  */
 
 /* Default */

--- a/styles/content/table/styles/table-cell-selected/variables.less
+++ b/styles/content/table/styles/table-cell-selected/variables.less
@@ -200,7 +200,7 @@
 @table-cell-selected-inverse-text-shadow: null;
 @table-cell-selected-inverse-text-decoration: null;
 @table-cell-selected-inverse-text-rendering: null;
-@table-cell-selected-inverse-background-color: color-lighten(@neutral, -15);
+@table-cell-selected-inverse-background-color: color-lighten(@neutral, 0);
 @table-cell-selected-inverse-background-gradient-color-top: null;
 @table-cell-selected-inverse-background-gradient-color-bottom: null;
 @table-cell-selected-inverse-border-width: null;
@@ -222,7 +222,7 @@
 
 // Hover
 
-@table-cell-selected-inverse-hover-color: color-lighten(@neutral, 90);
+@table-cell-selected-inverse-hover-color: null;
 @table-cell-selected-inverse-hover-font-family: null;
 @table-cell-selected-inverse-hover-font-style: null;
 @table-cell-selected-inverse-hover-font-weight: null;
@@ -230,7 +230,7 @@
 @table-cell-selected-inverse-hover-text-shadow: null;
 @table-cell-selected-inverse-hover-text-decoration: null;
 @table-cell-selected-inverse-hover-text-rendering: null;
-@table-cell-selected-inverse-hover-background-color: color-lighten(@neutral, -15);
+@table-cell-selected-inverse-hover-background-color: color-lighten(@neutral, 0);
 @table-cell-selected-inverse-hover-background-gradient-color-top: null;
 @table-cell-selected-inverse-hover-background-gradient-color-bottom: null;
 @table-cell-selected-inverse-hover-border-width: null;
@@ -284,7 +284,7 @@
 
 // Normal
 
-@table-cell-selected-inverse-active-color: null;
+@table-cell-selected-inverse-active-color: color-lighten(@neutral, 90);
 @table-cell-selected-inverse-active-font-family: null;
 @table-cell-selected-inverse-active-font-style: null;
 @table-cell-selected-inverse-active-font-weight: null;
@@ -292,7 +292,7 @@
 @table-cell-selected-inverse-active-text-shadow: null;
 @table-cell-selected-inverse-active-text-decoration: null;
 @table-cell-selected-inverse-active-text-rendering: null;
-@table-cell-selected-inverse-active-background-color: null;
+@table-cell-selected-inverse-active-background-color: color-lighten(@neutral, 0);
 @table-cell-selected-inverse-active-background-gradient-color-top: null;
 @table-cell-selected-inverse-active-background-gradient-color-bottom: null;
 @table-cell-selected-inverse-active-border-width: null;
@@ -314,7 +314,7 @@
 
 // Hover
 
-@table-cell-selected-inverse-active-hover-color: color-lighten(@neutral, 95);
+@table-cell-selected-inverse-active-hover-color: null;
 @table-cell-selected-inverse-active-hover-font-family: null;
 @table-cell-selected-inverse-active-hover-font-style: null;
 @table-cell-selected-inverse-active-hover-font-weight: null;
@@ -322,7 +322,7 @@
 @table-cell-selected-inverse-active-hover-text-shadow: null;
 @table-cell-selected-inverse-active-hover-text-decoration: null;
 @table-cell-selected-inverse-active-hover-text-rendering: null;
-@table-cell-selected-inverse-active-hover-background-color: color-lighten(@neutral, -5);
+@table-cell-selected-inverse-active-hover-background-color: color-lighten(@neutral, 4);
 @table-cell-selected-inverse-active-hover-background-gradient-color-top: null;
 @table-cell-selected-inverse-active-hover-background-gradient-color-bottom: null;
 @table-cell-selected-inverse-active-hover-border-width: null;

--- a/styles/content/table/styles/table-cell-selected/variables.less
+++ b/styles/content/table/styles/table-cell-selected/variables.less
@@ -1,7 +1,7 @@
 @table-cell-selected-enabled: @typography-enabled;
 
 /*
- * Tabel Cell Styling
+ * Table Cell Styling
  */
 
 /* Default */

--- a/styles/content/table/styles/table-cell-success/variables.less
+++ b/styles/content/table/styles/table-cell-success/variables.less
@@ -1,7 +1,7 @@
 @table-cell-success-enabled: @typography-enabled;
 
 /*
- * Tabel Cell Styling
+ * Table Cell Styling
  */
 
 /* Default */

--- a/styles/content/table/styles/table-cell-warning/variables.less
+++ b/styles/content/table/styles/table-cell-warning/variables.less
@@ -1,7 +1,7 @@
 @table-cell-warning-enabled: @typography-enabled;
 
 /*
- * Tabel Cell Styling
+ * Table Cell Styling
  */
 
 /* Default */

--- a/styles/content/table/variables.less
+++ b/styles/content/table/variables.less
@@ -56,7 +56,7 @@
 
 // Line Height
 
-@table-line-height: @table-font-size * 1.3;
+@table-line-height: @table-font-size * 1.1;
 @table-line-height-screen-small: null;
 @table-line-height-screen-medium: null;
 @table-line-height-screen-large: null;
@@ -70,7 +70,7 @@
 
 // Border Radius
 
-@table-border-radius: 5px;
+@table-border-radius: null;
 @table-border-radius-screen-small: null;
 @table-border-radius-screen-medium: null;
 @table-border-radius-screen-large: null;
@@ -374,7 +374,7 @@
 @table-cell-inverse-background-gradient-color-top: null;
 @table-cell-inverse-background-gradient-color-bottom: null;
 @table-cell-inverse-border-width: null;
-@table-cell-inverse-border-color: color-lighten(@neutral, -5);
+@table-cell-inverse-border-color: color-lighten(@neutral, 8);
 @table-cell-inverse-border-style: null;
 @table-cell-inverse-border-top-width: null;
 @table-cell-inverse-border-top-color: null;
@@ -400,7 +400,7 @@
 @table-cell-inverse-hover-text-shadow: null;
 @table-cell-inverse-hover-text-decoration: null;
 @table-cell-inverse-hover-text-rendering: null;
-@table-cell-inverse-hover-background-color: color-lighten(@neutral, -20);
+@table-cell-inverse-hover-background-color: color-lighten(@neutral, 0);
 @table-cell-inverse-hover-background-gradient-color-top: null;
 @table-cell-inverse-hover-background-gradient-color-bottom: null;
 @table-cell-inverse-hover-border-width: null;
@@ -462,7 +462,7 @@
 @table-cell-inverse-active-text-shadow: null;
 @table-cell-inverse-active-text-decoration: null;
 @table-cell-inverse-active-text-rendering: null;
-@table-cell-inverse-active-background-color: color-lighten(@neutral, -15);
+@table-cell-inverse-active-background-color: color-lighten(@neutral, 0);
 @table-cell-inverse-active-background-gradient-color-top: null;
 @table-cell-inverse-active-background-gradient-color-bottom: null;
 @table-cell-inverse-active-border-width: null;
@@ -492,7 +492,7 @@
 @table-cell-inverse-active-hover-text-shadow: null;
 @table-cell-inverse-active-hover-text-decoration: null;
 @table-cell-inverse-active-hover-text-rendering: null;
-@table-cell-inverse-active-hover-background-color: color-lighten(@neutral, -5);
+@table-cell-inverse-active-hover-background-color: color-lighten(@neutral, 4);
 @table-cell-inverse-active-hover-background-gradient-color-top: null;
 @table-cell-inverse-active-hover-background-gradient-color-bottom: null;
 @table-cell-inverse-active-hover-border-width: null;
@@ -548,7 +548,7 @@
 
 // Font Size
 
-@table-cell-font-size: 1rem;
+@table-cell-font-size: null;
 @table-cell-font-size-screen-small: null;
 @table-cell-font-size-screen-medium: null;
 @table-cell-font-size-screen-large: null;
@@ -556,7 +556,7 @@
 
 // Line Height
 
-@table-cell-line-height: @table-cell-font-size * 1.1;
+@table-cell-line-height: null;
 @table-cell-line-height-screen-small: null;
 @table-cell-line-height-screen-medium: null;
 @table-cell-line-height-screen-large: null;
@@ -642,11 +642,11 @@
 @table-header-font-family: null;
 @table-header-font-style: null;
 @table-header-font-weight: 600;
-@table-header-text-transform: null;
+@table-header-text-transform: uppercase;
 @table-header-text-shadow: null;
 @table-header-text-decoration: null;
 @table-header-text-rendering: null;
-@table-header-background-color: color-lighten(@neutral, 95);
+@table-header-background-color: null;
 @table-header-background-gradient-color-top: null;
 @table-header-background-gradient-color-bottom: null;
 @table-header-border-width: null;
@@ -676,7 +676,7 @@
 @table-header-hover-text-shadow: null;
 @table-header-hover-text-decoration: null;
 @table-header-hover-text-rendering: null;
-@table-header-hover-background-color: color-lighten(@neutral, 92);
+@table-header-hover-background-color: color-lighten(@neutral, 94);
 @table-header-hover-background-gradient-color-top: null;
 @table-header-hover-background-gradient-color-bottom: null;
 @table-header-hover-border-width: null;
@@ -738,7 +738,7 @@
 @table-header-active-text-shadow: null;
 @table-header-active-text-decoration: null;
 @table-header-active-text-rendering: null;
-@table-header-active-background-color: color-lighten(@neutral, 90);
+@table-header-active-background-color: color-lighten(@neutral, 94);
 @table-header-active-background-gradient-color-top: null;
 @table-header-active-background-gradient-color-bottom: null;
 @table-header-active-border-width: null;
@@ -768,7 +768,7 @@
 @table-header-active-hover-text-shadow: null;
 @table-header-active-hover-text-decoration: null;
 @table-header-active-hover-text-rendering: null;
-@table-header-active-hover-background-color: color-lighten(@neutral, 90);
+@table-header-active-hover-background-color: color-lighten(@neutral, 92);
 @table-header-active-hover-background-gradient-color-top: null;
 @table-header-active-hover-background-gradient-color-bottom: null;
 @table-header-active-hover-border-width: null;
@@ -830,11 +830,11 @@
 @table-header-inverse-text-shadow: null;
 @table-header-inverse-text-decoration: null;
 @table-header-inverse-text-rendering: null;
-@table-header-inverse-background-color: color-lighten(@neutral, 0);
+@table-header-inverse-background-color: null;
 @table-header-inverse-background-gradient-color-top: null;
 @table-header-inverse-background-gradient-color-bottom: null;
 @table-header-inverse-border-width: null;
-@table-header-inverse-border-color: color-lighten(@neutral, 0);
+@table-header-inverse-border-color: null;
 @table-header-inverse-border-style: null;
 @table-header-inverse-border-top-width: null;
 @table-header-inverse-border-top-color: null;
@@ -860,11 +860,11 @@
 @table-header-inverse-hover-text-shadow: null;
 @table-header-inverse-hover-text-decoration: null;
 @table-header-inverse-hover-text-rendering: null;
-@table-header-inverse-hover-background-color: color-lighten(@neutral, 3);
+@table-header-inverse-hover-background-color: color-lighten(@neutral, 4);
 @table-header-inverse-hover-background-gradient-color-top: null;
 @table-header-inverse-hover-background-gradient-color-bottom: null;
 @table-header-inverse-hover-border-width: null;
-@table-header-inverse-hover-border-color: color-lighten(@neutral, 3);
+@table-header-inverse-hover-border-color: null;
 @table-header-inverse-hover-border-style: null;
 @table-header-inverse-hover-border-top-width: null;
 @table-header-inverse-hover-border-top-color: null;
@@ -922,11 +922,11 @@
 @table-header-inverse-active-text-shadow: null;
 @table-header-inverse-active-text-decoration: null;
 @table-header-inverse-active-text-rendering: null;
-@table-header-inverse-active-background-color: color-lighten(@neutral, 7);
+@table-header-inverse-active-background-color: color-lighten(@neutral, 4);
 @table-header-inverse-active-background-gradient-color-top: null;
 @table-header-inverse-active-background-gradient-color-bottom: null;
 @table-header-inverse-active-border-width: null;
-@table-header-inverse-active-border-color: color-lighten(@neutral, 7);
+@table-header-inverse-active-border-color: null;
 @table-header-inverse-active-border-style: null;
 @table-header-inverse-active-border-top-width: null;
 @table-header-inverse-active-border-top-color: null;
@@ -952,11 +952,11 @@
 @table-header-inverse-active-hover-text-shadow: null;
 @table-header-inverse-active-hover-text-decoration: null;
 @table-header-inverse-active-hover-text-rendering: null;
-@table-header-inverse-active-hover-background-color: color-lighten(@neutral, 7);
+@table-header-inverse-active-hover-background-color: color-lighten(@neutral, 8);
 @table-header-inverse-active-hover-background-gradient-color-top: null;
 @table-header-inverse-active-hover-background-gradient-color-bottom: null;
 @table-header-inverse-active-hover-border-width: null;
-@table-header-inverse-active-hover-border-color: color-lighten(@neutral, 7);
+@table-header-inverse-active-hover-border-color: null;
 @table-header-inverse-active-hover-border-style: null;
 @table-header-inverse-active-hover-border-top-width: null;
 @table-header-inverse-active-hover-border-top-color: null;
@@ -1016,11 +1016,11 @@
 
 // Line Height
 
-@table-header-line-height: @table-header-font-size * 1.3;
-@table-header-line-height-screen-small: null;
-@table-header-line-height-screen-medium: null;
-@table-header-line-height-screen-large: null;
-@table-header-line-height-screen-jumbo: null;
+@table-header-line-height: @table-line-height;
+@table-header-line-height-screen-small: @table-line-height-screen-small;
+@table-header-line-height-screen-medium: @table-line-height-screen-medium;
+@table-header-line-height-screen-large: @table-line-height-screen-large;
+@table-header-line-height-screen-jumbo: @table-line-height-screen-jumbo;
 
 /* Margin */
 

--- a/styles/content/table/variables.less
+++ b/styles/content/table/variables.less
@@ -1016,11 +1016,11 @@
 
 // Line Height
 
-@table-header-line-height: @table-line-height;
-@table-header-line-height-screen-small: @table-line-height-screen-small;
-@table-header-line-height-screen-medium: @table-line-height-screen-medium;
-@table-header-line-height-screen-large: @table-line-height-screen-large;
-@table-header-line-height-screen-jumbo: @table-line-height-screen-jumbo;
+@table-header-line-height: null;
+@table-header-line-height-screen-small: null;
+@table-header-line-height-screen-medium: null;
+@table-header-line-height-screen-large: null;
+@table-header-line-height-screen-jumbo: null;
 
 /* Margin */
 

--- a/styles/content/table/variables.less
+++ b/styles/content/table/variables.less
@@ -171,7 +171,7 @@
 @table-tall-padding-right-scale: null;
 
 /*
- * Tabel Cell Styling
+ * Table Cell Styling
  */
 
 /* Default */
@@ -631,7 +631,7 @@
 @table-cell-padding-right-screen-jumbo: null;
 
 /*
- * Tabel Header Styling
+ * Table Header Styling
  */
 
 /* Default */
@@ -1003,7 +1003,7 @@
 @table-header-inverse-active-disabled-shadow: null;
 
 /*
- * Tabel Header Text Size
+ * Table Header Text Size
  */
 
 // Font Size

--- a/styles/content/table/variables.less
+++ b/styles/content/table/variables.less
@@ -392,7 +392,7 @@
 
 // Hover
 
-@table-cell-inverse-hover-color: color-lighten(@neutral, 80);
+@table-cell-inverse-hover-color: null;
 @table-cell-inverse-hover-font-family: null;
 @table-cell-inverse-hover-font-style: null;
 @table-cell-inverse-hover-font-weight: null;
@@ -484,7 +484,7 @@
 
 // Hover
 
-@table-cell-inverse-active-hover-color: color-lighten(@neutral, 95);
+@table-cell-inverse-active-hover-color: null;
 @table-cell-inverse-active-hover-font-family: null;
 @table-cell-inverse-active-hover-font-style: null;
 @table-cell-inverse-active-hover-font-weight: null;


### PR DESCRIPTION
Review/Merge this PR first - https://github.com/mesosphere/canvas/pull/55

* Made a number of updates to the default table styles to align with the default DC/OS UI style.
* Introduced `.table-flush` to strip away horizontal padding
* Fixed a bug on the borderless class