### PR TITLE
Give custom toggle labels a min-height

### DIFF
--- a/styles/components/form/form-control-toggle/styles.less
+++ b/styles/components/form/form-control-toggle/styles.less
@@ -87,10 +87,7 @@
       /* Custom Toggles */
 
       &.form-control-toggle-custom {
-
-        & when not (@toggle-custom-height = null) {
-          min-height: @toggle-custom-height;
-        }
+        .property-variant(toggle-custom, min-height, height, null, null);
 
         input[type='checkbox'],
         input[type='radio'] {
@@ -559,10 +556,7 @@
           /* Custom Toggles */
 
           &.form-control-toggle-custom {
-
-            & when not (@toggle-custom-height-screen-small = null) {
-              min-height: @toggle-custom-height-screen-small;
-            }
+            .property-variant(toggle-custom, min-height, height, null, screen-small);
 
             .form-control-toggle-indicator {
               .property-variant(toggle-custom, width, screen-small);
@@ -606,10 +600,7 @@
           /* Custom Toggles */
 
           &.form-control-toggle-custom {
-
-            & when not (@toggle-custom-height-screen-medium = null) {
-              min-height: @toggle-custom-height-screen-medium;
-            }
+            .property-variant(toggle-custom, min-height, height, null, screen-medium);
 
             .form-control-toggle-indicator {
               .property-variant(toggle-custom, width, screen-medium);
@@ -653,10 +644,7 @@
           /* Custom Toggles */
 
           &.form-control-toggle-custom {
-
-            & when not (@toggle-custom-height-screen-large = null) {
-              min-height: @toggle-custom-height-screen-large;
-            }
+            .property-variant(toggle-custom, min-height, height, null, screen-large);
 
             .form-control-toggle-indicator {
               .property-variant(toggle-custom, width, screen-large);
@@ -700,10 +688,7 @@
           /* Custom Toggles */
 
           &.form-control-toggle-custom {
-
-            & when not (@toggle-custom-height-screen-jumbo = null) {
-              min-height: @toggle-custom-height-screen-jumbo;
-            }
+            .property-variant(toggle-custom, min-height, height, null, screen-jumbo);
 
             .form-control-toggle-indicator {
               .property-variant(toggle-custom, width, screen-jumbo);

--- a/styles/components/form/form-control-toggle/styles.less
+++ b/styles/components/form/form-control-toggle/styles.less
@@ -88,6 +88,10 @@
 
       &.form-control-toggle-custom {
 
+        & when not (@toggle-custom-height = null) {
+          min-height: @toggle-custom-height;
+        }
+
         input[type='checkbox'],
         input[type='radio'] {
           opacity: 0;
@@ -556,6 +560,10 @@
 
           &.form-control-toggle-custom {
 
+            & when not (@toggle-custom-height-screen-small = null) {
+              min-height: @toggle-custom-height-screen-small;
+            }
+
             .form-control-toggle-indicator {
               .property-variant(toggle-custom, width, screen-small);
               .property-variant(toggle-custom, height, screen-small);
@@ -598,6 +606,10 @@
           /* Custom Toggles */
 
           &.form-control-toggle-custom {
+
+            & when not (@toggle-custom-height-screen-medium = null) {
+              min-height: @toggle-custom-height-screen-medium;
+            }
 
             .form-control-toggle-indicator {
               .property-variant(toggle-custom, width, screen-medium);
@@ -642,6 +654,10 @@
 
           &.form-control-toggle-custom {
 
+            & when not (@toggle-custom-height-screen-large = null) {
+              min-height: @toggle-custom-height-screen-large;
+            }
+
             .form-control-toggle-indicator {
               .property-variant(toggle-custom, width, screen-large);
               .property-variant(toggle-custom, height, screen-large);
@@ -684,6 +700,10 @@
           /* Custom Toggles */
 
           &.form-control-toggle-custom {
+
+            & when not (@toggle-custom-height-screen-jumbo = null) {
+              min-height: @toggle-custom-height-screen-jumbo;
+            }
 
             .form-control-toggle-indicator {
               .property-variant(toggle-custom, width, screen-jumbo);


### PR DESCRIPTION
In DCOS UI we sometimes use checkboxes without any text (tables w/ checkboxes). Due to the absolute positioning of the indicators, there's nothing to give the label height. This PR will ensure that the label will always be at least as tall as the indicator.

@ashenden Let me know if this should be a variable of its own rather than just using the one for `height`.