### PR TITLE
Introduce .badge-info badge style

### DIFF
--- a/docs/_includes/components/badges/badges-states.html
+++ b/docs/_includes/components/badges/badges-states.html
@@ -38,6 +38,12 @@ BEGIN: Badge States
 
         </span>
 
+        <span class="badge badge-info">
+
+          Information
+
+        </span>
+
         <span class="badge badge-warning">
 
           Warning
@@ -65,6 +71,11 @@ BEGIN: Badge States
 &lt;!-- badge: Success --&gt;
 &lt;span class="badge badge-success"&gt;
   Success
+&lt;/span&gt;
+
+&lt;!-- badge: Info --&gt;
+&lt;span class="badge badge-info"&gt;
+  Info
 &lt;/span&gt;
 
 &lt;!-- badge: Warning --&gt;

--- a/styles/cnvs.less
+++ b/styles/cnvs.less
@@ -131,6 +131,8 @@
 
 // Badge Styles
 
+@import 'components/badges/styles/badge-info/variables.less';
+@import 'components/badges/styles/badge-info/styles.less';
 @import 'components/badges/styles/badge-success/variables.less';
 @import 'components/badges/styles/badge-success/styles.less';
 @import 'components/badges/styles/badge-warning/variables.less';

--- a/styles/components/badges/styles/badge-info/styles.less
+++ b/styles/components/badges/styles/badge-info/styles.less
@@ -1,0 +1,15 @@
+& when (@badge-enabled) {
+  /* Badge */
+
+  .badge-info {
+    .element-shape-style(badge-info);
+    .element-text-style(badge-info);
+
+    /* Badge Inverse (.badge-inverse) */
+
+    &.badge-inverse {
+      .element-shape-style(badge-info-inverse);
+      .element-text-style(badge-info-inverse);
+    }
+  }
+}

--- a/styles/components/badges/styles/badge-info/variables.less
+++ b/styles/components/badges/styles/badge-info/variables.less
@@ -1,0 +1,65 @@
+@badge-info-enabled: true;
+
+/*
+ * Styling
+ */
+
+/* Default */
+
+@badge-info-color: @white;
+@badge-info-font-family: null;
+@badge-info-font-style: null;
+@badge-info-font-weight: null;
+@badge-info-text-transform: null;
+@badge-info-text-shadow: null;
+@badge-info-text-decoration: null;
+@badge-info-text-rendering: null;
+@badge-info-background-color: @blue;
+@badge-info-background-gradient-color-top: null;
+@badge-info-background-gradient-color-bottom: null;
+@badge-info-border-width: null;
+@badge-info-border-color: @blue;
+@badge-info-border-style: null;
+@badge-info-border-top-width: null;
+@badge-info-border-top-color: null;
+@badge-info-border-top-style: null;
+@badge-info-border-right-width: null;
+@badge-info-border-right-color: null;
+@badge-info-border-right-style: null;
+@badge-info-border-bottom-width: null;
+@badge-info-border-bottom-color: null;
+@badge-info-border-bottom-style: null;
+@badge-info-border-left-width: null;
+@badge-info-border-left-color: null;
+@badge-info-border-left-style: null;
+@badge-info-shadow: null;
+
+/* Inverse */
+
+@badge-info-inverse-color: null;
+@badge-info-inverse-font-family: null;
+@badge-info-inverse-font-style: null;
+@badge-info-inverse-font-weight: null;
+@badge-info-inverse-text-transform: null;
+@badge-info-inverse-text-shadow: null;
+@badge-info-inverse-text-decoration: null;
+@badge-info-inverse-text-rendering: null;
+@badge-info-inverse-background-color: null;
+@badge-info-inverse-background-gradient-color-top: null;
+@badge-info-inverse-background-gradient-color-bottom: null;
+@badge-info-inverse-border-width: null;
+@badge-info-inverse-border-color: null;
+@badge-info-inverse-border-style: null;
+@badge-info-inverse-border-top-width: null;
+@badge-info-inverse-border-top-color: null;
+@badge-info-inverse-border-top-style: null;
+@badge-info-inverse-border-right-width: null;
+@badge-info-inverse-border-right-color: null;
+@badge-info-inverse-border-right-style: null;
+@badge-info-inverse-border-bottom-width: null;
+@badge-info-inverse-border-bottom-color: null;
+@badge-info-inverse-border-bottom-style: null;
+@badge-info-inverse-border-left-width: null;
+@badge-info-inverse-border-left-color: null;
+@badge-info-inverse-border-left-style: null;
+@badge-info-inverse-shadow: null;


### PR DESCRIPTION
This PR introduces a new `.badge-info` badge style

![image](https://cloud.githubusercontent.com/assets/883486/22993451/63165910-f3c3-11e6-8024-47450c6f496f.png)
