### PR TITLE
Fix bullet line height to align center.

### DIFF
--- a/styles/content/typography/lists/variables.less
+++ b/styles/content/typography/lists/variables.less
@@ -246,26 +246,26 @@
 
 // Width
 
-@list-item-bullet-width: 16px * 0.3;
+@list-item-bullet-width: floor(14px * 0.35);
 @list-item-bullet-width-screen-small: null;
-@list-item-bullet-width-screen-medium: floor(1.05 * @list-item-bullet-width);
-@list-item-bullet-width-screen-large: floor(1.1 * @list-item-bullet-width);
+@list-item-bullet-width-screen-medium: null;
+@list-item-bullet-width-screen-large: floor(15px * 0.35);
 @list-item-bullet-width-screen-jumbo: null;
 
 // Height
 
-@list-item-bullet-height: 16px * 0.3;
+@list-item-bullet-height: floor(14px * 0.35);
 @list-item-bullet-height-screen-small: null;
-@list-item-bullet-height-screen-medium: floor(1.05 * @list-item-bullet-height);
-@list-item-bullet-height-screen-large: floor(1.1 * @list-item-bullet-height);
+@list-item-bullet-height-screen-medium: null;
+@list-item-bullet-height-screen-large: floor(15px * 0.35);
 @list-item-bullet-height-screen-jumbo: null;
 
 // Line Height
 
-@list-item-bullet-line-height: 16px * 1.4;
+@list-item-bullet-line-height: 14px * 1.3;
 @list-item-bullet-line-height-screen-small: null;
-@list-item-bullet-line-height-screen-medium: floor(1.05 * @list-item-bullet-line-height);
-@list-item-bullet-line-height-screen-large: floor(0.9 * @list-item-bullet-line-height);
+@list-item-bullet-line-height-screen-medium: null;
+@list-item-bullet-line-height-screen-large: 15px * 1.3;
 @list-item-bullet-line-height-screen-jumbo: null;
 
 /*

--- a/styles/content/typography/lists/variables.less
+++ b/styles/content/typography/lists/variables.less
@@ -265,7 +265,7 @@
 @list-item-bullet-line-height: 16px * 1.4;
 @list-item-bullet-line-height-screen-small: null;
 @list-item-bullet-line-height-screen-medium: floor(1.05 * @list-item-bullet-line-height);
-@list-item-bullet-line-height-screen-large: floor(1.1 * @list-item-bullet-line-height);
+@list-item-bullet-line-height-screen-large: floor(0.9 * @list-item-bullet-line-height);
 @list-item-bullet-line-height-screen-jumbo: null;
 
 /*


### PR DESCRIPTION
This PR is a fix for DCOS-14170, aligning the bullet center.

![screen shot 2017-04-04 at 2 07 15 pm](https://cloud.githubusercontent.com/assets/549394/24678601/0cecaee8-1940-11e7-95f3-50db53cfbf28.png)
