### PR TITLE
Changing container margin from `0` to `auto`.

### DIFF
--- a/styles/layout/container/variables.less
+++ b/styles/layout/container/variables.less
@@ -43,7 +43,7 @@
 
 @container-margin-left: @base-spacing-unit;
 @container-margin-left-screen-small: @base-spacing-unit-screen-small;
-@container-margin-left-screen-medium: 0;
+@container-margin-left-screen-medium: auto;
 @container-margin-left-screen-large: null;
 @container-margin-left-screen-jumbo: null;
 


### PR DESCRIPTION
This fixes an issue with medium viewport + devices with containers not centering due to margins not being set to  `auto`